### PR TITLE
Implement tenant-aware parcel capture and offline queue

### DIFF
--- a/lobbybox-guard/src/App.tsx
+++ b/lobbybox-guard/src/App.tsx
@@ -5,6 +5,7 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {enableScreens} from 'react-native-screens';
 import {AppNavigator} from '@/navigation/AppNavigator';
 import {AuthProvider} from '@/context/AuthContext';
+import {ParcelQueueProvider} from '@/context/ParcelQueueContext';
 import {ThemeProvider} from '@/theme';
 
 enableScreens();
@@ -18,7 +19,9 @@ const App: React.FC = () => {
         <QueryClientProvider client={queryClient}>
           <ThemeProvider>
             <AuthProvider>
-              <AppNavigator />
+              <ParcelQueueProvider>
+                <AppNavigator />
+              </ParcelQueueProvider>
             </AuthProvider>
           </ThemeProvider>
         </QueryClientProvider>

--- a/lobbybox-guard/src/api/types.ts
+++ b/lobbybox-guard/src/api/types.ts
@@ -1,11 +1,19 @@
 export type Role = 'GUARD' | 'ADMIN' | 'MANAGER' | 'RESIDENT' | string;
 
+export type PropertyAssignment = {
+  propertyId: string;
+  propertyName: string;
+};
+
 export type User = {
   id: string;
   email: string;
   name: string;
   role: Role;
+  propertyAssignment?: PropertyAssignment | null;
 };
+
+export type GuardProfile = User;
 
 export type AuthResponse = {
   accessToken: string;
@@ -36,4 +44,21 @@ export type CreateParcelPayload = {
   propertyId: string;
   photoUrl: string;
   remarks?: string;
+};
+
+export type ParcelQueryParams = {
+  page?: number;
+  pageSize?: number;
+  from?: string;
+  to?: string;
+  q?: string;
+  propertyId?: string;
+};
+
+export type PaginatedParcelsResponse = {
+  items: Parcel[];
+  page: number;
+  pageSize: number;
+  total: number;
+  hasMore: boolean;
 };

--- a/lobbybox-guard/src/context/ParcelQueueContext.tsx
+++ b/lobbybox-guard/src/context/ParcelQueueContext.tsx
@@ -1,0 +1,208 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import NetInfo, {NetInfoState} from '@react-native-community/netinfo';
+import {useQueryClient} from '@tanstack/react-query';
+import {requestParcelUpload, uploadParcelImage, createParcel} from '@/api/parcels';
+import {loadParcelQueue, persistParcelQueue, StoredParcelQueueItem, ParcelQueueStatus} from '@/storage/parcelQueueStorage';
+import {showToast} from '@/utils/toast';
+
+export type ParcelQueueItem = StoredParcelQueueItem;
+
+type EnqueuePayload = {
+  localUri: string;
+  propertyId: string;
+  remarks?: string;
+};
+
+type ParcelQueueContextValue = {
+  items: ParcelQueueItem[];
+  isOnline: boolean;
+  enqueue: (payload: EnqueuePayload) => Promise<ParcelQueueItem>;
+  retry: (id: string) => Promise<void>;
+};
+
+const ParcelQueueContext = createContext<ParcelQueueContextValue | undefined>(undefined);
+
+const getBackoffDelay = (tries: number) => Math.min(2 ** tries * 1000, 60_000);
+
+const shouldAttempt = (item: ParcelQueueItem) => {
+  if (item.status === 'queued' || item.status === 'uploading') {
+    return true;
+  }
+  if (item.status === 'failed') {
+    if (!item.lastAttemptAt) {
+      return true;
+    }
+    const lastAttempt = new Date(item.lastAttemptAt).getTime();
+    const delay = getBackoffDelay(item.tries);
+    return Date.now() - lastAttempt >= delay;
+  }
+  return false;
+};
+
+const generateId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+export const ParcelQueueProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
+  const [items, setItems] = useState<ParcelQueueItem[]>([]);
+  const [isOnline, setIsOnline] = useState<boolean>(false);
+  const isProcessing = useRef(false);
+  const retryTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queueRef = useRef<ParcelQueueItem[]>([]);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queueRef.current = items;
+    void persistParcelQueue(items);
+  }, [items]);
+
+  useEffect(() => {
+    const load = async () => {
+      const stored = await loadParcelQueue();
+      setItems(stored);
+    };
+    void load();
+  }, []);
+
+  useEffect(() => {
+    const syncState = (state: NetInfoState) => {
+      const online = Boolean(state.isConnected && state.isInternetReachable !== false);
+      setIsOnline(online);
+    };
+
+    const unsubscribe = NetInfo.addEventListener(syncState);
+    void NetInfo.fetch().then(syncState);
+    return unsubscribe;
+  }, []);
+
+  const updateItem = useCallback((id: string, updater: Partial<ParcelQueueItem>) => {
+    setItems(prev => prev.map(item => (item.id === id ? {...item, ...updater} : item)));
+  }, []);
+
+  const removeItem = useCallback((id: string) => {
+    setItems(prev => prev.filter(item => item.id !== id));
+  }, []);
+
+  const processQueue = useCallback(async () => {
+    if (isProcessing.current || !isOnline) {
+      return;
+    }
+    isProcessing.current = true;
+    try {
+      for (const item of queueRef.current) {
+        if (!shouldAttempt(item)) {
+          continue;
+        }
+        const attemptId = item.id;
+        const nextTries = item.tries + 1;
+        updateItem(attemptId, {
+          status: 'uploading',
+          tries: nextTries,
+          lastAttemptAt: new Date().toISOString(),
+          error: null,
+        });
+        try {
+          const {uploadUrl, blobUrl} = await requestParcelUpload({ext: 'jpg'});
+          await uploadParcelImage(uploadUrl, item.localUri);
+          await createParcel({
+            propertyId: item.propertyId,
+            photoUrl: blobUrl,
+            remarks: item.remarks,
+          });
+          removeItem(attemptId);
+          await queryClient.invalidateQueries({queryKey: ['parcels'], exact: false});
+          await queryClient.invalidateQueries({queryKey: ['parcels-history'], exact: false});
+          showToast('Queued parcel synced');
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to sync parcel.';
+          updateItem(attemptId, {
+            status: 'failed',
+            error: message,
+          });
+          const delay = getBackoffDelay(nextTries);
+          if (retryTimeout.current) {
+            clearTimeout(retryTimeout.current);
+          }
+          if (isOnline) {
+            retryTimeout.current = setTimeout(() => {
+              retryTimeout.current = null;
+              void processQueue();
+            }, delay);
+          }
+        }
+      }
+    } finally {
+      isProcessing.current = false;
+    }
+  }, [isOnline, queryClient, removeItem, updateItem]);
+
+  useEffect(() => {
+    if (isOnline) {
+      void processQueue();
+    }
+  }, [isOnline, processQueue]);
+
+  const enqueue = useCallback(
+    async ({localUri, propertyId, remarks}: EnqueuePayload) => {
+      const item: ParcelQueueItem = {
+        id: generateId(),
+        localUri,
+        propertyId,
+        remarks,
+        createdAt: new Date().toISOString(),
+        status: 'queued',
+        tries: 0,
+        error: null,
+        lastAttemptAt: null,
+      };
+      setItems(prev => [...prev, item]);
+      if (isOnline) {
+        void processQueue();
+      }
+      return item;
+    },
+    [isOnline, processQueue],
+  );
+
+  const retry = useCallback(
+    async (id: string) => {
+      const item = queueRef.current.find(entry => entry.id === id);
+      if (!item) {
+        return;
+      }
+      updateItem(id, {status: 'queued', tries: 0, error: null, lastAttemptAt: null});
+      if (isOnline) {
+        void processQueue();
+      }
+    },
+    [isOnline, processQueue, updateItem],
+  );
+
+  const value = useMemo(
+    () => ({
+      items,
+      isOnline,
+      enqueue,
+      retry,
+    }),
+    [enqueue, isOnline, items, retry],
+  );
+
+  return <ParcelQueueContext.Provider value={value}>{children}</ParcelQueueContext.Provider>;
+};
+
+export const useParcelQueueContext = () => {
+  const context = useContext(ParcelQueueContext);
+  if (!context) {
+    throw new Error('useParcelQueue must be used within ParcelQueueProvider');
+  }
+  return context;
+};
+
+export type ParcelQueueState = ParcelQueueStatus;

--- a/lobbybox-guard/src/hooks/useParcelQueue.ts
+++ b/lobbybox-guard/src/hooks/useParcelQueue.ts
@@ -1,0 +1,3 @@
+import {useParcelQueueContext} from '@/context/ParcelQueueContext';
+
+export const useParcelQueue = () => useParcelQueueContext();

--- a/lobbybox-guard/src/screens/App/HistoryScreen.tsx
+++ b/lobbybox-guard/src/screens/App/HistoryScreen.tsx
@@ -1,30 +1,308 @@
-import React from 'react';
-import {FlatList, StyleSheet, Text, View} from 'react-native';
+import React, {useCallback, useMemo, useState} from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 import dayjs from 'dayjs';
+import {useInfiniteQuery} from '@tanstack/react-query';
 import {ScreenContainer} from '@/components/ScreenContainer';
 import {useThemeContext} from '@/theme';
+import {fetchParcelsPage} from '@/api/parcels';
+import {Parcel, ParcelQueryParams} from '@/api/types';
+import {useAuth} from '@/hooks/useAuth';
+import {Button} from '@/components/Button';
+import {useParcelQueue} from '@/hooks/useParcelQueue';
 
-const mockHistory = [
-  {id: 'h1', title: 'Package logged', date: dayjs().subtract(1, 'day').toISOString()},
-  {id: 'h2', title: 'Maintenance escort', date: dayjs().subtract(2, 'day').toISOString()},
-  {id: 'h3', title: 'Night patrol', date: dayjs().subtract(3, 'day').toISOString()},
-];
+const PAGE_SIZE = 20;
+
+const formatTimestamp = (value: string) => {
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed.format('MMM D, YYYY • HH:mm') : value;
+};
+
+type FilterForm = {
+  from: string;
+  to: string;
+  q: string;
+};
+
+type ParcelListItem = Parcel;
+
+type QueueListItemProps = {
+  label: string;
+  status: string;
+  subtitle?: string | null;
+  createdAt: string;
+  onRetry?: () => void;
+};
+
+const QueueListItem: React.FC<QueueListItemProps> = ({label, status, subtitle, createdAt, onRetry}) => {
+  const {theme} = useThemeContext();
+  return (
+    <View style={[styles.queueItem, {borderColor: theme.colors.border}]}> 
+      <View style={styles.queueItemHeader}>
+        <Text style={[styles.queueItemLabel, {color: theme.colors.text}]}>{label}</Text>
+        <Text style={[styles.queueItemStatus, {color: theme.colors.secondary}]}>{status}</Text>
+      </View>
+      <Text style={{color: theme.colors.muted, marginBottom: subtitle ? 8 : 0}}>{formatTimestamp(createdAt)}</Text>
+      {subtitle ? <Text style={{color: theme.colors.muted, marginBottom: 12}}>{subtitle}</Text> : null}
+      {onRetry ? (
+        <Button title="Retry" variant="secondary" onPress={onRetry} style={styles.queueRetryButton} />
+      ) : null}
+    </View>
+  );
+};
+
+const ParcelHistoryCard: React.FC<{parcel: ParcelListItem}> = ({parcel}) => {
+  const {theme} = useThemeContext();
+  return (
+    <View style={[styles.card, {backgroundColor: theme.colors.card, borderColor: theme.colors.border}]}> 
+      <View style={styles.cardHeader}>
+        <Text style={[styles.cardTitle, {color: theme.colors.text}]}>{parcel.recipientName ?? 'Parcel'}</Text>
+        {parcel.trackingNumber ? (
+          <Text style={{color: theme.colors.muted}}>#{parcel.trackingNumber}</Text>
+        ) : null}
+      </View>
+      {parcel.remarks ? <Text style={{color: theme.colors.muted, marginBottom: 8}}>{parcel.remarks}</Text> : null}
+      <Text style={{color: theme.colors.text}}>{formatTimestamp(parcel.createdAt)}</Text>
+    </View>
+  );
+};
 
 export const HistoryScreen: React.FC = () => {
   const {theme} = useThemeContext();
+  const {property, refreshProfile} = useAuth();
+  const {items: queueItems, retry: retryQueueItem, isOnline} = useParcelQueue();
+  const propertyId = property?.propertyId;
+
+  const [form, setForm] = useState<FilterForm>({from: '', to: '', q: ''});
+  const [filters, setFilters] = useState<FilterForm>(form);
+
+  const onChangeField = useCallback(
+    (key: keyof FilterForm, value: string) => {
+      setForm(prev => ({...prev, [key]: value}));
+    },
+    [],
+  );
+
+  const handleApplyFilters = useCallback(() => {
+    setFilters(form);
+  }, [form]);
+
+  const handleClearFilters = useCallback(() => {
+    const cleared = {from: '', to: '', q: ''};
+    setForm(cleared);
+    setFilters(cleared);
+  }, []);
+
+  const queryKey = useMemo(
+    () => ['parcels-history', propertyId, filters.from, filters.to, filters.q],
+    [filters.from, filters.to, filters.q, propertyId],
+  );
+
+  const parcelsQuery = useInfiniteQuery({
+    queryKey,
+    enabled: Boolean(propertyId),
+    initialPageParam: 1,
+    getNextPageParam: lastPage => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+    queryFn: async ({pageParam}) => {
+      const params: ParcelQueryParams = {
+        page: pageParam,
+        pageSize: PAGE_SIZE,
+        propertyId: propertyId ?? undefined,
+      };
+      if (filters.from) {
+        params.from = filters.from;
+      }
+      if (filters.to) {
+        params.to = filters.to;
+      }
+      if (filters.q) {
+        params.q = filters.q;
+      }
+      return fetchParcelsPage(params);
+    },
+  });
+
+  const {
+    data,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+    isFetching,
+  } = parcelsQuery;
+
+  const parcels = useMemo(() => data?.pages.flatMap(page => page.items) ?? [], [data]);
+
+  const isRefreshing = isFetching && !isLoading && !isFetchingNextPage;
+
+  const errorMessage = useMemo(() => {
+    if (!error) {
+      return null;
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return 'Unable to load history. Please try again later.';
+  }, [error]);
+
+  const handleLoadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const renderParcel = useCallback(({item}: {item: ParcelListItem}) => <ParcelHistoryCard parcel={item} />, []);
+
+  const queuedItems = useMemo(
+    () => queueItems.filter(item => item.status === 'queued' || item.status === 'uploading'),
+    [queueItems],
+  );
+  const failedItems = useMemo(() => queueItems.filter(item => item.status === 'failed'), [queueItems]);
+
+  if (!propertyId) {
+    return (
+      <ScreenContainer>
+        <View style={styles.messageContainer}>
+          <Text style={[styles.heading, {color: theme.colors.text}]}>History</Text>
+          <Text style={[styles.messageTitle, {color: theme.colors.text}]}>Property assignment required</Text>
+          <Text style={[styles.messageBody, {color: theme.colors.muted}]}>We couldn't find an assigned property for your account. Please contact your administrator or try refreshing your assignment.</Text>
+          <Button title="Retry assignment" onPress={() => refreshProfile()} />
+        </View>
+      </ScreenContainer>
+    );
+  }
+
+  const ListHeaderComponent = (
+    <View>
+      <Text style={[styles.heading, {color: theme.colors.text}]}>
+        History{property?.propertyName ? ` · ${property.propertyName}` : ''}
+      </Text>
+      <View style={[styles.filterCard, {backgroundColor: theme.colors.card, borderColor: theme.colors.border}]}> 
+        <Text style={[styles.filterTitle, {color: theme.colors.text}]}>Filters</Text>
+        <View style={styles.filterRow}>
+          <View style={[styles.filterField, styles.filterFieldSpacing]}>
+            <Text style={[styles.filterLabel, {color: theme.colors.muted}]}>From</Text>
+            <TextInput
+              value={form.from}
+              placeholder="YYYY-MM-DD"
+              placeholderTextColor={theme.colors.muted}
+              onChangeText={value => onChangeField('from', value)}
+              style={[styles.input, {color: theme.colors.text, borderColor: theme.colors.border}]}
+            />
+          </View>
+          <View style={styles.filterField}>
+            <Text style={[styles.filterLabel, {color: theme.colors.muted}]}>To</Text>
+            <TextInput
+              value={form.to}
+              placeholder="YYYY-MM-DD"
+              placeholderTextColor={theme.colors.muted}
+              onChangeText={value => onChangeField('to', value)}
+              style={[styles.input, {color: theme.colors.text, borderColor: theme.colors.border}]}
+            />
+          </View>
+        </View>
+        <View style={styles.filterField}>
+          <Text style={[styles.filterLabel, {color: theme.colors.muted}]}>Search</Text>
+          <TextInput
+            value={form.q}
+            placeholder="Recipient or tracking"
+            placeholderTextColor={theme.colors.muted}
+            onChangeText={value => onChangeField('q', value)}
+            style={[styles.input, {color: theme.colors.text, borderColor: theme.colors.border}]}
+          />
+        </View>
+        <View style={styles.filterActions}>
+          <Button
+            title="Apply"
+            onPress={handleApplyFilters}
+            style={[styles.filterActionButton, styles.filterActionSpacing]}
+          />
+          <Button title="Clear" variant="secondary" onPress={handleClearFilters} style={styles.filterActionButton} />
+        </View>
+      </View>
+      {isLoading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="small" color={theme.colors.primary} />
+        </View>
+      ) : null}
+      {queuedItems.length > 0 ? (
+        <View style={[styles.queueCard, {backgroundColor: theme.colors.card, borderColor: theme.colors.border}]}> 
+          <Text style={[styles.queueHeading, {color: theme.colors.text}]}>Queued uploads</Text>
+          <Text style={{color: theme.colors.muted, marginBottom: 12}}>
+            {isOnline ? 'These parcels will sync shortly.' : 'Waiting for connection to sync.'}
+          </Text>
+          {queuedItems.map(item => (
+            <QueueListItem
+              key={item.id}
+              label={item.remarks ?? 'Parcel photo'}
+              status={item.status === 'uploading' ? 'Syncing…' : 'Queued'}
+              createdAt={item.createdAt}
+            />
+          ))}
+        </View>
+      ) : null}
+      {failedItems.length > 0 ? (
+        <View style={[styles.queueCard, {backgroundColor: theme.colors.card, borderColor: theme.colors.border}]}> 
+          <Text style={[styles.queueHeading, {color: theme.colors.text}]}>Failed uploads</Text>
+          <Text style={{color: theme.colors.muted, marginBottom: 12}}>Retry to attempt syncing again.</Text>
+          {failedItems.map(item => (
+            <QueueListItem
+              key={item.id}
+              label={item.remarks ?? 'Parcel photo'}
+              status="Failed"
+              createdAt={item.createdAt}
+              subtitle={item.error ?? undefined}
+              onRetry={() => retryQueueItem(item.id)}
+            />
+          ))}
+        </View>
+      ) : null}
+      {errorMessage ? (
+        <View style={styles.errorContainer}>
+          <Text style={[styles.errorText, {color: theme.colors.notification}]}>{errorMessage}</Text>
+          <Button title="Retry" variant="secondary" onPress={() => refetch()} style={styles.errorButton} />
+        </View>
+      ) : null}
+    </View>
+  );
 
   return (
     <ScreenContainer>
       <FlatList
-        data={mockHistory}
+        data={parcels}
         keyExtractor={item => item.id}
-        renderItem={({item}) => (
-          <View style={[styles.card, {backgroundColor: theme.colors.card, borderColor: theme.colors.border}]}> 
-            <Text style={[styles.cardTitle, {color: theme.colors.text}]}>{item.title}</Text>
-            <Text style={{color: theme.colors.muted}}>{dayjs(item.date).format('MMM D, YYYY h:mm A')}</Text>
-          </View>
-        )}
-        ListHeaderComponent={<Text style={[styles.heading, {color: theme.colors.text}]}>History</Text>}
+        renderItem={renderParcel}
+        contentContainerStyle={styles.listContent}
+        ItemSeparatorComponent={() => <View style={styles.separator} />}
+        ListHeaderComponent={ListHeaderComponent}
+        onEndReached={handleLoadMore}
+        onEndReachedThreshold={0.5}
+        refreshControl={
+          <RefreshControl refreshing={isRefreshing} onRefresh={refetch} tintColor={theme.colors.primary} />
+        }
+        ListEmptyComponent={
+          !isLoading && parcels.length === 0 && !errorMessage ? (
+            <Text style={{color: theme.colors.muted, textAlign: 'center', marginTop: 24}}>
+              No parcels match your filters yet.
+            </Text>
+          ) : null
+        }
+        ListFooterComponent={
+          isFetchingNextPage ? (
+            <View style={styles.footerLoading}>
+              <ActivityIndicator size="small" color={theme.colors.primary} />
+            </View>
+          ) : null
+        }
       />
     </ScreenContainer>
   );
@@ -40,11 +318,133 @@ const styles = StyleSheet.create({
     padding: 16,
     borderRadius: 12,
     borderWidth: 1,
-    marginBottom: 12,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
   },
   cardTitle: {
     fontSize: 16,
     fontWeight: '600',
-    marginBottom: 6,
+  },
+  listContent: {
+    paddingBottom: 48,
+    paddingHorizontal: 4,
+  },
+  separator: {
+    height: 12,
+  },
+  filterCard: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 16,
+  },
+  filterTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  filterRow: {
+    flexDirection: 'row',
+  },
+  filterField: {
+    flex: 1,
+    marginBottom: 12,
+  },
+  filterFieldSpacing: {
+    marginRight: 12,
+  },
+  filterLabel: {
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+  },
+  filterActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+  },
+  filterActionButton: {
+    flex: 1,
+  },
+  filterActionSpacing: {
+    marginRight: 12,
+  },
+  queueCard: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 16,
+  },
+  queueHeading: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  queueItem: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+  },
+  queueItemHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  queueItemLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    flex: 1,
+    marginRight: 12,
+  },
+  queueItemStatus: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  queueRetryButton: {
+    alignSelf: 'flex-start',
+  },
+  errorContainer: {
+    marginTop: 12,
+  },
+  errorText: {
+    fontSize: 14,
+  },
+  errorButton: {
+    marginTop: 8,
+  },
+  loadingContainer: {
+    paddingVertical: 8,
+  },
+  footerLoading: {
+    paddingVertical: 16,
+  },
+  messageContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    paddingTop: 32,
+  },
+  messageTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  messageBody: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: 16,
   },
 });

--- a/lobbybox-guard/src/storage/parcelQueueStorage.ts
+++ b/lobbybox-guard/src/storage/parcelQueueStorage.ts
@@ -1,0 +1,41 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type ParcelQueueStatus = 'queued' | 'uploading' | 'failed';
+
+export type StoredParcelQueueItem = {
+  id: string;
+  localUri: string;
+  propertyId: string;
+  remarks?: string;
+  createdAt: string;
+  status: ParcelQueueStatus;
+  tries: number;
+  error?: string | null;
+  lastAttemptAt?: string | null;
+};
+
+const STORAGE_KEY = '@lobbybox/parcel-queue/v1';
+
+export const loadParcelQueue = async (): Promise<StoredParcelQueueItem[]> => {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed as StoredParcelQueueItem[];
+  } catch (err) {
+    return [];
+  }
+};
+
+export const persistParcelQueue = async (items: StoredParcelQueueItem[]): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch (err) {
+    // noop - we will retry persistence on next mutation
+  }
+};


### PR DESCRIPTION
## Summary
- load the guard's assigned property during authentication and expose it throughout the app
- gate capture/today/history experiences on property assignment while passing property ids to parcel APIs
- add an offline-first parcel queue with AsyncStorage persistence, NetInfo-driven syncing, and history filters with infinite scrolling and retry support

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68de2d98a7088331816aa6577c4502f7