### PR TITLE
fix: use available react-native-codegen version

### DIFF
--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -45,7 +45,7 @@
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "metro-react-native-babel-preset": "^0.76.8",
-    "react-native-codegen": "^0.74.9",
+    "react-native-codegen": "^0.74.3",
     "react-test-renderer": "18.2.0",
     "typescript": "^5.3.3",
     "babel-plugin-module-resolver": "^5.0.0"


### PR DESCRIPTION
## Summary
- adjust the react-native-codegen dev dependency to a published 0.74.x version to resolve installation failures

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de647d8f3c833187520e314b5b26ac