### PR TITLE
Fix React Native project naming to avoid CLI validation errors

### DIFF
--- a/lobbybox-guard/README.md
+++ b/lobbybox-guard/README.md
@@ -8,7 +8,7 @@ Foundational React Native (0.74) application targeting security guards. Built wi
 
 The native projects are intentionally excluded from this repository snapshot (see note below). Once you generate the iOS and Android folders, apply the following hardening items before archiving release builds:
 
-### iOS (`ios/lobbybox-guard/Info.plist`)
+### iOS (`ios/LobbyboxGuard/Info.plist`)
 
 ```xml
 <key>NSCameraUsageDescription</key>
@@ -44,8 +44,6 @@ Store capture payloads inside scoped storage (`context.getExternalFilesDir`) and
 
 ## Getting Started
 
-## Getting Started
-
 1. Install dependencies
 
 ```bash
@@ -65,7 +63,7 @@ npm run android
 npm run ios
 ```
 
-> **Note:** Native iOS/Android projects are not included in this repository snapshot. Generate them with `npx @react-native-community/cli init lobbybox-guard --template react-native-template-typescript` if you need native build scaffolding.
+> **Note:** Native iOS/Android projects are not included in this repository snapshot. Generate them with `npx @react-native-community/cli init LobbyboxGuard --template react-native-template-typescript` if you need native build scaffolding. The React Native CLI requires the project name to be alphanumeric, so avoid hyphens or other punctuation when choosing the identifier.
 
 ## Configuration
 

--- a/lobbybox-guard/app.json
+++ b/lobbybox-guard/app.json
@@ -1,4 +1,4 @@
 {
-  "name": "lobbybox-guard",
+  "name": "LobbyboxGuard",
   "displayName": "Lobbybox Guard"
 }

--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lobbybox-guard",
+  "name": "lobbyboxguard",
   "version": "0.0.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- rename the package and app identifiers to an alphanumeric form accepted by the React Native CLI
- document the updated iOS path and command usage, noting the CLI naming restrictions

## Testing
- npm test -- --watchAll=false *(fails: jest not found before dependencies could be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68de8c9411b883318a7d38e824eefccc