### PR TITLE
Fix react-native-codegen version constraint

### DIFF
--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -45,7 +45,7 @@
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "metro-react-native-babel-preset": "^0.76.8",
-    "react-native-codegen": "^0.74.1",
+    "react-native-codegen": "^0.74.0",
     "react-test-renderer": "18.2.0",
     "typescript": "^5.3.3",
     "babel-plugin-module-resolver": "^5.0.0"


### PR DESCRIPTION
## Summary
- update the react-native-codegen dev dependency to a published 0.74.x release so installs no longer fail with ETARGET

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68de8ddc8f8c83318c161522a5b59e28