### PR TITLE
Configure Jest path aliases and native mocks

### DIFF
--- a/lobbybox-guard/jest.config.js
+++ b/lobbybox-guard/jest.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   preset: 'react-native',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
   transformIgnorePatterns: [
     'node_modules/(?!(react-native' +
       '|@react-native' +

--- a/lobbybox-guard/jest.setup.js
+++ b/lobbybox-guard/jest.setup.js
@@ -7,3 +7,14 @@ jest.mock('@react-native-community/netinfo', () => ({
   addEventListener: jest.fn(),
   fetch: jest.fn(),
 }));
+jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
+jest.mock('react-native-vision-camera', () => ({
+  Camera: jest.fn().mockImplementation(() => null),
+  CameraRuntimeError: class MockCameraRuntimeError extends Error {},
+  useCameraDevice: jest.fn(() => null),
+  useCameraPermission: jest.fn(() => ({
+    hasPermission: false,
+    requestPermission: jest.fn(),
+    status: 'not-determined',
+  })),
+}));


### PR DESCRIPTION
## Summary
- align Jest with the Metro/Babel alias configuration so `@/` imports resolve
- stub native React Native modules (Reanimated, Vision Camera) to prevent test crashes on RN 0.74

## Testing
- not run (dependency installation is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de90f1bda08331abea987f20e4d817