### PR TITLE
docs: add helper script for generating native projects

### DIFF
--- a/lobbybox-guard/.gitignore
+++ b/lobbybox-guard/.gitignore
@@ -1,7 +1,5 @@
 # React Native
 node_modules/
-android/
-ios/
 build/
 .expo/
 web-build/

--- a/lobbybox-guard/README.md
+++ b/lobbybox-guard/README.md
@@ -63,7 +63,7 @@ npm run android
 npm run ios
 ```
 
-> **Note:** Native iOS/Android projects are not included in this repository snapshot. Generate them with `npx @react-native-community/cli init LobbyboxGuard --template react-native-template-typescript` if you need native build scaffolding. The React Native CLI requires the project name to be alphanumeric, so avoid hyphens or other punctuation when choosing the identifier.
+> **Note:** Native iOS/Android projects are not included in this repository snapshot by default. Run [`scripts/setup-native.sh`](./scripts/setup-native.sh) to scaffold them locally using the React Native CLI (`npx react-native@0.74.3 init ...`). The helper script mirrors the TypeScript template and copies the generated `android` and `ios` directories into this workspace. The React Native CLI requires the project name to be alphanumeric, so avoid hyphens or other punctuation when choosing the identifier.
 
 ## Configuration
 

--- a/lobbybox-guard/scripts/setup-native.sh
+++ b/lobbybox-guard/scripts/setup-native.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEMPLATE_NAME="LobbyboxGuardNativeTemplate"
+RN_VERSION="0.74.3"
+
+cleanup() {
+  if [ -d "$PROJECT_ROOT/$TEMPLATE_NAME" ]; then
+    rm -rf "$PROJECT_ROOT/$TEMPLATE_NAME"
+  fi
+}
+
+trap cleanup EXIT
+
+if [ -d "$PROJECT_ROOT/android" ] || [ -d "$PROJECT_ROOT/ios" ]; then
+  echo "android or ios directories already exist. Remove them before running this script." >&2
+  exit 1
+fi
+
+echo "Generating React Native native projects (android and ios)..."
+
+npx --yes react-native@${RN_VERSION} init "$TEMPLATE_NAME" --skip-install
+
+cp -R "$PROJECT_ROOT/$TEMPLATE_NAME/android" "$PROJECT_ROOT/android"
+cp -R "$PROJECT_ROOT/$TEMPLATE_NAME/ios" "$PROJECT_ROOT/ios"
+
+cleanup
+
+echo "android and ios directories have been generated."


### PR DESCRIPTION
## Summary
- stop ignoring the android and ios directories so the native projects can be versioned when generated
- add a setup script that boots the React Native CLI and copies the scaffolded android and ios folders into the repo
- update the README to point at the helper script for generating native projects locally

## Testing
- not run (network access is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df1af496808331ae32e4c320cbac58