### PR TITLE
Improve native scaffolding script compatibility on Windows

### DIFF
--- a/lobbybox-guard/scripts/setup-native.sh
+++ b/lobbybox-guard/scripts/setup-native.sh
@@ -4,10 +4,15 @@ set -euo pipefail
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 TEMPLATE_NAME="LobbyboxGuardNativeTemplate"
 RN_VERSION="0.74.3"
+RN_CLI_PACKAGE="@react-native-community/cli"
+RN_CLI_VERSION="12.4.1"
+
+TMP_ROOT=$(mktemp -d 2>/dev/null || mktemp -d -t lobbybox-guard-native)
+TEMPLATE_PATH="$TMP_ROOT/$TEMPLATE_NAME"
 
 cleanup() {
-  if [ -d "$PROJECT_ROOT/$TEMPLATE_NAME" ]; then
-    rm -rf "$PROJECT_ROOT/$TEMPLATE_NAME"
+  if [ -d "$TMP_ROOT" ]; then
+    rm -rf "$TMP_ROOT"
   fi
 }
 
@@ -20,10 +25,29 @@ fi
 
 echo "Generating React Native native projects (android and ios)..."
 
-npx --yes react-native@${RN_VERSION} init "$TEMPLATE_NAME" --skip-install
+if command -v npx.cmd >/dev/null 2>&1; then
+  NPX_BIN="npx.cmd"
+else
+  NPX_BIN="npx"
+fi
 
-cp -R "$PROJECT_ROOT/$TEMPLATE_NAME/android" "$PROJECT_ROOT/android"
-cp -R "$PROJECT_ROOT/$TEMPLATE_NAME/ios" "$PROJECT_ROOT/ios"
+"$NPX_BIN" --yes ${RN_CLI_PACKAGE}@${RN_CLI_VERSION} init "$TEMPLATE_NAME" \
+  --version ${RN_VERSION} \
+  --directory "$TEMPLATE_PATH" \
+  --skip-install \
+  --install-pods false \
+  --package-manager npm
+
+ANDROID_SOURCE="$TEMPLATE_PATH/android"
+IOS_SOURCE="$TEMPLATE_PATH/ios"
+
+if [ ! -d "$ANDROID_SOURCE" ] || [ ! -d "$IOS_SOURCE" ]; then
+  echo "React Native CLI did not generate the expected android/ios projects. Review the output above for details." >&2
+  exit 1
+fi
+
+cp -R "$ANDROID_SOURCE" "$PROJECT_ROOT/android"
+cp -R "$IOS_SOURCE" "$PROJECT_ROOT/ios"
 
 cleanup
 


### PR DESCRIPTION
## Summary
- scaffold the temporary React Native template with the community CLI to improve Windows support
- disable pod installation, prefer npm, and detect npx.cmd to avoid platform-specific failures
- verify the generated android/ios folders exist before copying them into the workspace

## Testing
- not run (npm registry access is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df27fb13ac8331ba0b80ce5f289f23