### PR TITLE
Update React Native CLI version in setup script

### DIFF
--- a/lobbybox-guard/scripts/setup-native.sh
+++ b/lobbybox-guard/scripts/setup-native.sh
@@ -5,7 +5,7 @@ PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 TEMPLATE_NAME="LobbyboxGuardNativeTemplate"
 RN_VERSION="0.74.3"
 RN_CLI_PACKAGE="@react-native-community/cli"
-RN_CLI_VERSION="12.4.1"
+RN_CLI_VERSION="13.6.9"
 
 TMP_ROOT=$(mktemp -d 2>/dev/null || mktemp -d -t lobbybox-guard-native)
 TEMPLATE_PATH="$TMP_ROOT/$TEMPLATE_NAME"


### PR DESCRIPTION
## Summary
- update the setup-native script to request React Native CLI 13.6.9 so the download succeeds

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df29f6413883319aff236e139a1240