### PR TITLE
Work around Android dependency version constraints

### DIFF
--- a/lobbybox-guard/android/build.gradle
+++ b/lobbybox-guard/android/build.gradle
@@ -26,10 +26,20 @@ apply plugin: "com.facebook.react.rootproject"
 // still compile against the older React Native version that the app uses.
 subprojects { subproject ->
     if (subproject.name == "react-native-reanimated") {
-        subproject.afterEvaluate {
-            def task = subproject.tasks.findByName("assertMinimalReactNativeVersionTask")
-            if (task != null) {
+        subproject.tasks.configureEach { task ->
+            if (task.name == "assertMinimalReactNativeVersionTask") {
                 task.enabled = false
+            }
+        }
+    }
+
+    subproject.configurations.configureEach { configuration ->
+        configuration.resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == "androidx.core" &&
+                (details.requested.name == "core" || details.requested.name == "core-ktx") &&
+                details.requested.version?.startsWith("1.16")) {
+                details.useVersion("1.12.0")
+                details.because("Android Gradle Plugin 8.2.1 only supports compileSdk up to 34")
             }
         }
     }


### PR DESCRIPTION
## Summary
- disable the react-native-reanimated minimal React Native version assertion task via Gradle task configuration to allow building on React Native 0.74
- pin androidx.core core/core-ktx dependencies to version 1.12.0 so the project can continue compiling with Android Gradle Plugin 8.2.1 and compileSdk 34

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df3521f4308331980adedf72bdf59e