### PR TITLE
Add FileProvider file_paths resource

### DIFF
--- a/lobbybox-guard/android/app/src/main/res/xml/file_paths.xml
+++ b/lobbybox-guard/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="camera" path="." />
+    <external-files-path name="external" path="." />
+</paths>


### PR DESCRIPTION
## Summary
- add the missing `file_paths.xml` resource referenced by the Android manifest
- configure FileProvider to expose cache and external file locations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3c6812808331994cea3378c7cfb2