### PR TITLE
Fix React Native 0.74 build failure with reanimated border radii patch

### DIFF
--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -7,7 +7,8 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "postinstall": "node scripts/patch-react-native-reanimated.js"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.22.1",

--- a/lobbybox-guard/scripts/patch-react-native-reanimated.js
+++ b/lobbybox-guard/scripts/patch-react-native-reanimated.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+const targetFile = path.join(
+  __dirname,
+  '..',
+  'node_modules',
+  'react-native-reanimated',
+  'android',
+  'src',
+  'reactNativeVersionPatch',
+  'BorderRadiiDrawableUtils',
+  '75',
+  'com',
+  'swmansion',
+  'reanimated',
+  'BorderRadiiDrawableUtils.java'
+);
+
+const patchMarker = 'ReactViewBackgroundDrawable';
+const replacement = `package com.swmansion.reanimated;\n\nimport android.graphics.drawable.Drawable;\nimport android.view.View;\nimport com.facebook.react.views.view.ReactViewBackgroundDrawable;\nimport com.facebook.react.views.view.ReactViewBackgroundDrawable.BorderRadiusLocation;\n\npublic class BorderRadiiDrawableUtils {\n  public static ReactNativeUtils.BorderRadii getBorderRadii(View view) {\n    Drawable background = view.getBackground();\n    if (background instanceof ReactViewBackgroundDrawable) {\n      ReactViewBackgroundDrawable drawable = (ReactViewBackgroundDrawable) background;\n      return new ReactNativeUtils.BorderRadii(\n          drawable.getFullBorderRadius(),\n          drawable.getBorderRadiusOrDefaultTo(Float.NaN, BorderRadiusLocation.TOP_LEFT),\n          drawable.getBorderRadiusOrDefaultTo(Float.NaN, BorderRadiusLocation.TOP_RIGHT),\n          drawable.getBorderRadiusOrDefaultTo(Float.NaN, BorderRadiusLocation.BOTTOM_LEFT),\n          drawable.getBorderRadiusOrDefaultTo(Float.NaN, BorderRadiusLocation.BOTTOM_RIGHT));\n    } else {\n      return new ReactNativeUtils.BorderRadii(0, 0, 0, 0, 0);\n    }\n  }\n}\n`;
+
+if (!fs.existsSync(targetFile)) {
+  console.warn('[patch-react-native-reanimated] File not found, skipping:', targetFile);
+  process.exit(0);
+}
+
+const current = fs.readFileSync(targetFile, 'utf8');
+if (current.includes(patchMarker)) {
+  console.log('[patch-react-native-reanimated] BorderRadiiDrawableUtils already patched.');
+  process.exit(0);
+}
+
+fs.writeFileSync(targetFile, replacement, 'utf8');
+console.log('[patch-react-native-reanimated] Patched BorderRadiiDrawableUtils for RN 0.74 compatibility.');


### PR DESCRIPTION
## Summary
- add a postinstall script that rewrites Reanimated's BorderRadiiDrawableUtils to use ReactViewBackgroundDrawable APIs available in React Native 0.74
- hook the postinstall script into the package.json scripts so installs automatically patch the dependency

## Testing
- ./gradlew compileDebugJavaWithJavac *(fails: Gradle distribution download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68df4177eb3c8331b0fc69a9c7bf34ef