### PR TITLE
Restore ViewManagerWithGeneratedInterface stub for Android build

### DIFF
--- a/lobbybox-guard/android/app/src/main/java/com/facebook/react/uimanager/ViewManagerWithGeneratedInterface.java
+++ b/lobbybox-guard/android/app/src/main/java/com/facebook/react/uimanager/ViewManagerWithGeneratedInterface.java
@@ -1,0 +1,17 @@
+package com.facebook.react.uimanager;
+
+import android.view.View;
+
+/**
+ * Compatibility stub for React Native libraries that still expect the legacy
+ * {@code ViewManagerWithGeneratedInterface} marker interface. React Native 0.76
+ * removed the type from the core package, but several community libraries –
+ * including react-native-gesture-handler – continue to reference it in their
+ * code-generated interfaces. Providing the stub keeps those interfaces on the
+ * classpath without affecting runtime behaviour because none of the
+ * implementations rely on its methods.
+ */
+public interface ViewManagerWithGeneratedInterface<T extends View> {
+  // Intentionally empty: the historical interface only acted as a marker to
+  // allow generated view manager delegates to share a common bound.
+}


### PR DESCRIPTION
## Summary
- add a compatibility stub for `ViewManagerWithGeneratedInterface` so libraries expecting the legacy interface can compile against React Native 0.76

## Testing
- ./gradlew :react-native-gesture-handler:compileDebugKotlin :react-native-vision-camera:compileDebugKotlin *(fails: unable to download Gradle distribution because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68df46bab81c8331b6cbc115ed033491