### PR TITLE
Update Android build tooling to support new SDK metadata

### DIFF
--- a/lobbybox-guard/android/build.gradle
+++ b/lobbybox-guard/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:8.7.3")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
     }

--- a/lobbybox-guard/android/gradle/wrapper/gradle-wrapper.properties
+++ b/lobbybox-guard/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- pin the Android Gradle Plugin to version 8.7.3 to handle SDK XML version 4
- update the Gradle wrapper to 8.7 to remain compatible with the newer plugin

## Testing
- ./gradlew -v *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68df4923d0648331b82dadd83e081509