### PR TITLE
Downgrade Android Gradle tooling to 8.6 to fix dependency accessor rename failure

### DIFF
--- a/lobbybox-guard/android/build.gradle
+++ b/lobbybox-guard/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.7.3")
+        classpath("com.android.tools.build:gradle:8.6.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
     }

--- a/lobbybox-guard/android/gradle/wrapper/gradle-wrapper.properties
+++ b/lobbybox-guard/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- downgrade the Android Gradle Plugin to 8.6.1 to avoid the dependency accessor rename failure on Windows
- align the Gradle wrapper with version 8.6.1 so the project uses the compatible distribution

## Testing
- ./gradlew --version *(fails in container: unable to download Gradle distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68df4b6bec98833180b7ddb6d9a34d4c