### PR TITLE
fix: patch React Native Gradle plugin for older Gradle versions

### DIFF
--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -8,7 +8,7 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint .",
-    "postinstall": "node scripts/patch-react-native-reanimated.js"
+    "postinstall": "node scripts/patch-react-native-reanimated.js && node scripts/patch-react-native-gradle-plugin.js"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.22.1",

--- a/lobbybox-guard/scripts/patch-react-native-gradle-plugin.js
+++ b/lobbybox-guard/scripts/patch-react-native-gradle-plugin.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+
+const targetFile = path.join(
+  __dirname,
+  '..',
+  'node_modules',
+  '@react-native',
+  'gradle-plugin',
+  'build.gradle.kts'
+);
+
+if (!fs.existsSync(targetFile)) {
+  console.warn('[patch-react-native-gradle-plugin] File not found, skipping:', targetFile);
+  process.exit(0);
+}
+
+const marker = 'private inline fun <reified T : Any> Project.serviceOf(): T';
+const raw = fs.readFileSync(targetFile, 'utf8');
+
+if (raw.includes(marker)) {
+  console.log('[patch-react-native-gradle-plugin] build.gradle.kts already patched.');
+  process.exit(0);
+}
+
+let updated = raw;
+
+const importNeedle = 'import org.gradle.configurationcache.extensions.serviceOf';
+if (updated.includes(importNeedle)) {
+  updated = updated.replace(
+    importNeedle,
+    'import org.gradle.api.Project\nimport org.gradle.api.internal.HasServices'
+  );
+} else if (!updated.includes('import org.gradle.api.internal.HasServices')) {
+  updated = updated.replace(
+    'import org.jetbrains.kotlin.gradle.tasks.KotlinCompile',
+    "import org.jetbrains.kotlin.gradle.tasks.KotlinCompile\nimport org.gradle.api.Project\nimport org.gradle.api.internal.HasServices"
+  );
+}
+
+const serviceCallNeedle = 'serviceOf<ModuleRegistry>()';
+if (updated.includes(serviceCallNeedle)) {
+  updated = updated.replace(serviceCallNeedle, 'project.serviceOf<ModuleRegistry>()');
+}
+
+if (!updated.includes(marker)) {
+  updated = `${updated}\nprivate fun <T : Any> Project.serviceOf(type: Class<T>): T =\n    (this as HasServices).services.get(type)\n\nprivate inline fun <reified T : Any> Project.serviceOf(): T = serviceOf(T::class.java)\n`;
+}
+
+fs.writeFileSync(targetFile, updated, 'utf8');
+console.log('[patch-react-native-gradle-plugin] Patched build.gradle.kts to avoid serviceOf import.');


### PR DESCRIPTION
## Summary
- add a postinstall patch that rewrites the React Native Gradle plugin to avoid using the unavailable configuration cache serviceOf helper
- update the postinstall script to run the new gradle plugin patch alongside the existing reanimated patch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df51fc35ac8331a781a70ff62265a4