### PR TITLE
Skip gradle plugin patch on newer React Native releases

### DIFF
--- a/lobbybox-guard/scripts/patch-react-native-gradle-plugin.js
+++ b/lobbybox-guard/scripts/patch-react-native-gradle-plugin.js
@@ -16,7 +16,15 @@ if (!fs.existsSync(targetFile)) {
 }
 
 const marker = 'private inline fun <reified T : Any> Project.serviceOf(): T';
+const importNeedle = 'import org.gradle.configurationcache.extensions.serviceOf';
 const raw = fs.readFileSync(targetFile, 'utf8');
+
+if (raw.includes(importNeedle)) {
+  console.log(
+    '[patch-react-native-gradle-plugin] build.gradle.kts uses configurationcache serviceOf. Skipping patch.'
+  );
+  process.exit(0);
+}
 
 if (raw.includes(marker)) {
   console.log('[patch-react-native-gradle-plugin] build.gradle.kts already patched.');
@@ -24,8 +32,6 @@ if (raw.includes(marker)) {
 }
 
 let updated = raw;
-
-const importNeedle = 'import org.gradle.configurationcache.extensions.serviceOf';
 if (updated.includes(importNeedle)) {
   updated = updated.replace(
     importNeedle,


### PR DESCRIPTION
## Summary
- skip the custom gradle-plugin patch when the upstream script already uses the configuration cache serviceOf helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df56dd125c8331bdc05deb68cf0c3c