### PR TITLE
chore: use available react native types version

### DIFF
--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.23.6",
     "@types/node": "^20.12.7",
     "@types/react": "~18.2.45",
-    "@types/react-native": "~0.74.0",
+    "@types/react-native": "^0.73.0",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary
- replace the unavailable `@types/react-native` `~0.74.0` dependency with the published `^0.73.0` release to resolve npm install failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0ae93e9108331ac7d685be374707a