### PR TITLE
Fix React Native type package version

### DIFF
--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.23.6",
     "@types/node": "^20.12.7",
     "@types/react": "~18.2.45",
-    "@types/react-native": "^0.74.0",
+    "@types/react-native": "~0.73.0",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary
- update the @types/react-native dev dependency to a published 0.73 release to resolve installation errors

## Testing
- npm install *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/@babel%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b74201388331b2ab968675105cfe