### PR TITLE
chore: update dependency versions to match Expo expectations

### DIFF
--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -28,14 +28,14 @@
     "react": "18.2.0",
     "react-native": "0.74.2",
     "react-native-gesture-handler": "~2.16.1",
-    "react-native-safe-area-context": "4.10.5",
-    "react-native-screens": "~3.32.0",
+    "react-native-safe-area-context": "~5.6.0",
+    "react-native-screens": "~4.16.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@babel/core": "^7.23.6",
     "@types/node": "^20.12.7",
-    "@types/react": "~18.2.45",
+    "@types/react": "~19.1.10",
     "@types/react-native": "~0.73.0",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",


### PR DESCRIPTION
## Summary
- update react-native-safe-area-context and react-native-screens to match Expo's expected versions
- bump @types/react so type definitions align with the project's dependency requirements

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0d387b6848331a87b4090e3f8cf75