### PR TITLE
Add missing babel preset dependency

### DIFF
--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -39,6 +39,7 @@
     "@types/react-native": "~0.73.0",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
+    "babel-preset-expo": "^10.0.1",
     "babel-plugin-module-resolver": "^5.0.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.56.0",


### PR DESCRIPTION
## Summary
- add the `babel-preset-expo` development dependency so Expo's Babel config can resolve it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d6fe395c8331addb022ea5df8e96