### PR TITLE
Add missing babel preset dependency and align React types

### DIFF
--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -35,10 +35,11 @@
   "devDependencies": {
     "@babel/core": "^7.23.6",
     "@types/node": "^20.12.7",
-    "@types/react": "~19.1.10",
+    "@types/react": "~18.2.66",
     "@types/react-native": "~0.73.0",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
+    "babel-preset-expo": "^10.0.1",
     "babel-plugin-module-resolver": "^5.0.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.56.0",


### PR DESCRIPTION
## Summary
- add the `babel-preset-expo` development dependency so Expo's Babel config can resolve it
- align `@types/react` to the React 18-compatible release to satisfy React Native's peer dependency

## Testing
- `npm install --package-lock-only` *(fails with 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d6fe395c8331addb022ea5df8e96