### PR TITLE
Fix Metro bundling failure from DebuggingOverlay codegen

### DIFF
--- a/lobbybox-guard/metro.config.js
+++ b/lobbybox-guard/metro.config.js
@@ -1,7 +1,32 @@
+const path = require('path');
+const {resolve} = require('metro-resolver');
 const {getDefaultConfig} = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 
 config.resolver.sourceExts.push('cjs');
+
+const debugOverlaySpecModule =
+  'react-native/src/private/specs/components/DebuggingOverlayNativeComponent';
+const debugOverlayShimPath = path.resolve(
+  __dirname,
+  'src/shims/DebuggingOverlayNativeComponent.js',
+);
+
+const defaultResolveRequest =
+  config.resolver.resolveRequest ?? ((context, moduleName, platform) =>
+    resolve(context, moduleName, platform),
+  );
+
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === debugOverlaySpecModule) {
+    return {
+      type: 'sourceFile',
+      filePath: debugOverlayShimPath,
+    };
+  }
+
+  return defaultResolveRequest(context, moduleName, platform);
+};
 
 module.exports = config;

--- a/lobbybox-guard/src/shims/DebuggingOverlayNativeComponent.js
+++ b/lobbybox-guard/src/shims/DebuggingOverlayNativeComponent.js
@@ -1,0 +1,9 @@
+import {View} from 'react-native';
+
+/**
+ * Metro attempts to codegen the DebuggingOverlay native component and fails
+ * because the upstream spec uses Flow's $ReadOnlyArray type, which isn't
+ * supported by the version of react-native-codegen bundled with Expo. We
+ * shim the module with a simple JS implementation so bundling can continue.
+ */
+export default View;


### PR DESCRIPTION
## Summary
- override Metro's resolver to redirect the DebuggingOverlay native component spec to a local shim
- add a lightweight shim so Expo no longer tries to codegen the Flow file that uses unsupported $ReadOnlyArray types

## Testing
- not run (network restrictions prevented installing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e0db8e0b448331aa1ac323cf2c8ad4