### PR TITLE
Fix syntax error in metro resolver fallback

### DIFF
--- a/lobbybox-guard/metro.config.js
+++ b/lobbybox-guard/metro.config.js
@@ -14,9 +14,9 @@ const debugOverlayShimPath = path.resolve(
 );
 
 const defaultResolveRequest =
-  config.resolver.resolveRequest ?? ((context, moduleName, platform) =>
-    resolve(context, moduleName, platform),
-  );
+  config.resolver.resolveRequest ??
+    ((context, moduleName, platform) =>
+      resolve(context, moduleName, platform));
 
 config.resolver.resolveRequest = (context, moduleName, platform) => {
   if (moduleName === debugOverlaySpecModule) {


### PR DESCRIPTION
## Summary
- fix the default resolveRequest fallback arrow function in metro.config.js to avoid a syntax error during parsing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0dd431ae88331b26b7d3341fb0d3c