### PR TITLE
Fix Metro shim resolution for DebuggingOverlay spec

### DIFF
--- a/lobbybox-guard/metro.config.js
+++ b/lobbybox-guard/metro.config.js
@@ -6,8 +6,8 @@ const config = getDefaultConfig(__dirname);
 
 config.resolver.sourceExts.push('cjs');
 
-const debugOverlaySpecModule =
-  'react-native/src/private/specs/components/DebuggingOverlayNativeComponent';
+const debugOverlaySpecModuleSuffix =
+  'src/private/specs/components/DebuggingOverlayNativeComponent';
 const debugOverlayShimPath = path.resolve(
   __dirname,
   'src/shims/DebuggingOverlayNativeComponent.js',
@@ -19,7 +19,11 @@ const defaultResolveRequest =
       resolve(context, moduleName, platform));
 
 config.resolver.resolveRequest = (context, moduleName, platform) => {
-  if (moduleName === debugOverlaySpecModule) {
+  const normalizedModuleName = moduleName
+    .replace(/\\/g, '/')
+    .replace(/\.js$/, '');
+
+  if (normalizedModuleName.endsWith(debugOverlaySpecModuleSuffix)) {
     return {
       type: 'sourceFile',
       filePath: debugOverlayShimPath,


### PR DESCRIPTION
## Summary
- normalize the DebuggingOverlay native component module name so the Metro shim is used even on Windows paths

## Testing
- npm run lint *(fails: ESLint couldn't find the config "@react-native/eslint-config")*

------
https://chatgpt.com/codex/tasks/task_e_68e0e11c63e88331a2020a3b7cd7cccb