### PR TITLE
Load TurboModule shim from the Expo entry point

### DIFF
--- a/lobbybox-guard/App.tsx
+++ b/lobbybox-guard/App.tsx
@@ -1,3 +1,4 @@
+import './src/shims/ensureTurboModuleInterop';
 import 'react-native-gesture-handler';
 import App from './src/App';
 

--- a/lobbybox-guard/index.js
+++ b/lobbybox-guard/index.js
@@ -1,0 +1,6 @@
+import './src/shims/ensureTurboModuleInterop';
+import 'react-native-gesture-handler';
+import registerRootComponent from 'expo/build/launch/registerRootComponent';
+import App from './App';
+
+registerRootComponent(App);

--- a/lobbybox-guard/src/shims/ensureTurboModuleInterop.ts
+++ b/lobbybox-guard/src/shims/ensureTurboModuleInterop.ts
@@ -1,0 +1,21 @@
+/**
+ * React Native 0.74 enables the bridgeless runtime in development by default.
+ * Metro attempts to resolve certain core modules (for example, PlatformConstants)
+ * through the TurboModule system, which isn't available when running inside Expo
+ * Go or the web bundler. When this happens the runtime throws an invariant
+ * because TurboModuleRegistry can't locate the module.
+ *
+ * Setting `global.RN$TurboInterop` to `true` restores the legacy NativeModules
+ * fallback path so TurboModuleRegistry can read core modules provided by Expo.
+ * The flag needs to be applied before any React Native imports execute.
+ */
+
+declare global {
+  // The flag is defined by React Native's TurboModuleRegistry runtime.
+  // eslint-disable-next-line no-var
+  var RN$TurboInterop: boolean | undefined;
+}
+
+if (globalThis.RN$TurboInterop !== true) {
+  globalThis.RN$TurboInterop = true;
+}


### PR DESCRIPTION
## Summary
- import the TurboModule interop shim from a custom Expo entry file so it runs before React Native modules load

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0e2e32ab88331ae85de6b02964666