### PR TITLE
Fix expo registerRootComponent import path

### DIFF
--- a/lobbybox-guard/index.js
+++ b/lobbybox-guard/index.js
@@ -1,6 +1,6 @@
 import './src/shims/ensureTurboModuleInterop';
 import 'react-native-gesture-handler';
-import registerRootComponent from 'expo/build/launch/registerRootComponent';
+import { registerRootComponent } from 'expo';
 import App from './App';
 
 registerRootComponent(App);


### PR DESCRIPTION
## Summary
- replace the direct path import of registerRootComponent with the public expo export to fix the module resolution error

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0e70ba3048331883b9eba03009036