### PR TITLE
Ensure TurboModule fallback flag applies to all globals

### DIFF
--- a/lobbybox-guard/src/shims/ensureTurboModuleInterop.ts
+++ b/lobbybox-guard/src/shims/ensureTurboModuleInterop.ts
@@ -16,6 +16,19 @@ declare global {
   var RN$TurboInterop: boolean | undefined;
 }
 
-if (globalThis.RN$TurboInterop !== true) {
-  globalThis.RN$TurboInterop = true;
-}
+type TurboInteropTarget = {
+  RN$TurboInterop?: boolean;
+};
+
+const setTurboInteropFlag = (target: TurboInteropTarget | undefined) => {
+  if (!target) {
+    return;
+  }
+
+  if (target.RN$TurboInterop !== true) {
+    target.RN$TurboInterop = true;
+  }
+};
+
+setTurboInteropFlag(typeof globalThis !== 'undefined' ? (globalThis as TurboInteropTarget) : undefined);
+setTurboInteropFlag(typeof global !== 'undefined' ? (global as TurboInteropTarget) : undefined);


### PR DESCRIPTION
## Summary
- update the TurboModule interop shim to safely set the RN$TurboInterop flag on both `globalThis` and `global`
- prevent the bridgeless runtime from missing core modules when either global reference is used

## Testing
- npm run lint *(fails: ESLint couldn't find the config "@react-native/eslint-config" referenced by .eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e47aa8748331ab81e8840cd18bce