### PR TITLE
Implement LobbyBox color tokens and theme roles

### DIFF
--- a/lobbybox-guard/src/components/Button.tsx
+++ b/lobbybox-guard/src/components/Button.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {StyleProp, StyleSheet, Text, TouchableOpacity, TouchableOpacityProps, ViewStyle} from 'react-native';
 import {useThemeContext} from '@/theme';
+import type {ThemeRoles} from '@/theme';
 
 type ButtonVariant = 'primary' | 'secondary' | 'ghost';
 
@@ -21,7 +22,7 @@ export const Button: React.FC<Props> = ({
   ...rest
 }) => {
   const {theme} = useThemeContext();
-  const styles = getStyles(theme.colors, disabled ?? false);
+  const styles = getStyles(theme.roles, disabled ?? false);
 
   const containerStyle = [styles.base, styles[variant], style];
   const textStyle = [styles.text, styles[`${variant}Text` as const]];
@@ -40,9 +41,7 @@ export const Button: React.FC<Props> = ({
   );
 };
 
-type ThemeColors = ReturnType<typeof useThemeContext>['theme']['colors'];
-
-const getStyles = (colors: ThemeColors, disabled: boolean) =>
+const getStyles = (roles: ThemeRoles, disabled: boolean) =>
   StyleSheet.create({
     base: {
       paddingVertical: 12,
@@ -58,23 +57,23 @@ const getStyles = (colors: ThemeColors, disabled: boolean) =>
       fontWeight: '600',
     },
     primary: {
-      backgroundColor: colors.primary,
+      backgroundColor: roles.button.primary.background,
     },
     primaryText: {
-      color: colors.background,
+      color: roles.button.primary.text,
     },
     secondary: {
-      backgroundColor: colors.surface,
+      backgroundColor: roles.button.secondary.background,
       borderWidth: 1,
-      borderColor: colors.border,
+      borderColor: roles.button.secondary.border,
     },
     secondaryText: {
-      color: colors.text,
+      color: roles.button.secondary.text,
     },
     ghost: {
       backgroundColor: 'transparent',
     },
     ghostText: {
-      color: colors.primary,
+      color: roles.button.ghost.text,
     },
   });

--- a/lobbybox-guard/src/components/DebugPanel.tsx
+++ b/lobbybox-guard/src/components/DebugPanel.tsx
@@ -27,30 +27,37 @@ export const DebugPanel: React.FC = () => {
   }, [loadTokens]);
 
   return (
-    <View style={[styles.container, {borderColor: theme.colors.border, backgroundColor: theme.colors.card}]}
+    <View
+      style={[
+        styles.container,
+        {
+          borderColor: theme.roles.card.border,
+          backgroundColor: theme.roles.card.background,
+        },
+      ]}
       accessible
       accessibilityLabel="Debug information">
       <View style={styles.headerRow}>
-        <Text style={[styles.title, {color: theme.colors.text}]}>Debug panel</Text>
+        <Text style={[styles.title, {color: theme.roles.text.primary}]}>Debug panel</Text>
         <TouchableOpacity onPress={loadTokens} accessibilityRole="button" accessibilityLabel="Reload tokens">
-          <Text style={[styles.action, {color: theme.colors.primary}]}>{loading ? 'Refreshing…' : 'Reload'}</Text>
+          <Text style={[styles.action, {color: theme.palette.primary.main}]}>{loading ? 'Refreshing…' : 'Reload'}</Text>
         </TouchableOpacity>
       </View>
       <View style={styles.item}>
-        <Text style={[styles.label, {color: theme.colors.muted}]}>Last request ID</Text>
-        <Text style={[styles.value, {color: theme.colors.text}]} selectable>
+        <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Last request ID</Text>
+        <Text style={[styles.value, {color: theme.roles.text.primary}]} selectable>
           {lastRequestId ?? '—'}
         </Text>
       </View>
       <View style={styles.item}>
-        <Text style={[styles.label, {color: theme.colors.muted}]}>Access token</Text>
-        <Text style={[styles.value, {color: theme.colors.text}]} selectable numberOfLines={4}>
+        <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Access token</Text>
+        <Text style={[styles.value, {color: theme.roles.text.primary}]} selectable numberOfLines={4}>
           {accessToken ?? '—'}
         </Text>
       </View>
       <View style={styles.item}>
-        <Text style={[styles.label, {color: theme.colors.muted}]}>Refresh token</Text>
-        <Text style={[styles.value, {color: theme.colors.text}]} selectable numberOfLines={4}>
+        <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Refresh token</Text>
+        <Text style={[styles.value, {color: theme.roles.text.primary}]} selectable numberOfLines={4}>
           {refreshToken ?? '—'}
         </Text>
       </View>

--- a/lobbybox-guard/src/components/ErrorNotice.tsx
+++ b/lobbybox-guard/src/components/ErrorNotice.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo, useState} from 'react';
 import {StyleProp, StyleSheet, Text, TouchableOpacity, View, ViewStyle} from 'react-native';
 import {useThemeContext} from '@/theme';
+import type {AppTheme} from '@/theme';
 import {Button} from './Button';
 import {ParsedApiError, getDisplayMessage} from '@/utils/error';
 
@@ -24,7 +25,7 @@ export const ErrorNotice: React.FC<Props> = ({
 
   const isForbidden = error.status === 403;
 
-  const styles = useMemo(() => getStyles(theme.colors, variant), [theme.colors, variant]);
+  const styles = useMemo(() => getStyles(theme, variant), [theme, variant]);
 
   const message = getDisplayMessage(error);
 
@@ -66,15 +67,13 @@ export const ErrorNotice: React.FC<Props> = ({
   );
 };
 
-type ThemeColors = ReturnType<typeof useThemeContext>['theme']['colors'];
-
-const getStyles = (colors: ThemeColors, variant: 'banner' | 'inline') =>
+const getStyles = (theme: AppTheme, variant: 'banner' | 'inline') =>
   StyleSheet.create({
     container: {
       borderRadius: 12,
       borderWidth: 1,
-      borderColor: colors.border,
-      backgroundColor: variant === 'banner' ? colors.card : colors.surface,
+      borderColor: theme.roles.card.border,
+      backgroundColor: variant === 'banner' ? theme.roles.card.background : theme.roles.input.background,
       padding: variant === 'banner' ? 16 : 12,
       marginTop: variant === 'banner' ? 0 : 8,
     },
@@ -86,18 +85,18 @@ const getStyles = (colors: ThemeColors, variant: 'banner' | 'inline') =>
     message: {
       flex: 1,
       marginRight: 12,
-      color: colors.notification,
+      color: theme.roles.status.error,
       fontSize: variant === 'banner' ? 15 : 14,
       fontWeight: '600',
     },
     detailsToggle: {
-      color: colors.primary,
+      color: theme.palette.primary.main,
       fontSize: 14,
       fontWeight: '600',
     },
     detailsText: {
       marginTop: 8,
-      color: colors.muted,
+      color: theme.roles.text.secondary,
       fontSize: 13,
     },
     actionsRow: {

--- a/lobbybox-guard/src/components/ProgressBar.tsx
+++ b/lobbybox-guard/src/components/ProgressBar.tsx
@@ -11,8 +11,10 @@ export const ProgressBar: React.FC<Props> = ({progress}) => {
   const clamped = Math.min(Math.max(progress, 0), 1);
 
   return (
-    <View style={[styles.track, {backgroundColor: theme.colors.border}]}>
-      <View style={[styles.fill, {width: `${clamped * 100}%`, backgroundColor: theme.colors.primary}]} />
+    <View style={[styles.track, {backgroundColor: theme.roles.divider.color}]}>
+      <View
+        style={[styles.fill, {width: `${clamped * 100}%`, backgroundColor: theme.roles.button.primary.background}]}
+      />
     </View>
   );
 };

--- a/lobbybox-guard/src/components/ScreenContainer.tsx
+++ b/lobbybox-guard/src/components/ScreenContainer.tsx
@@ -13,7 +13,7 @@ export const ScreenContainer: React.FC<Props> = ({children, style}) => {
 
   return (
     <SafeAreaView
-      style={[styles.container, {backgroundColor: theme.colors.background}, style]}
+      style={[styles.container, {backgroundColor: theme.roles.background.default}, style]}
       edges={['top', 'right', 'bottom', 'left']}>
       {children}
     </SafeAreaView>

--- a/lobbybox-guard/src/components/SplashScreen.tsx
+++ b/lobbybox-guard/src/components/SplashScreen.tsx
@@ -24,10 +24,10 @@ export const SplashScreen: React.FC = () => {
   }, [opacity, scale]);
 
   return (
-    <View style={[styles.container, {backgroundColor: theme.colors.background}]}>
+    <View style={[styles.container, {backgroundColor: theme.roles.background.default}]}>
       <Animated.View style={[styles.logoContainer, {opacity, transform: [{scale}]}]}>
-        <Text style={[styles.logoText, {color: theme.colors.primary}]}>LobbyBox</Text>
-        <Text style={[styles.subtitle, {color: theme.colors.muted}]}>Parcel Guard</Text>
+        <Text style={[styles.logoText, {color: theme.palette.primary.main}]}>LobbyBox</Text>
+        <Text style={[styles.subtitle, {color: theme.roles.text.secondary}]}>Parcel Guard</Text>
       </Animated.View>
     </View>
   );

--- a/lobbybox-guard/src/screens/App/HomeScreen.tsx
+++ b/lobbybox-guard/src/screens/App/HomeScreen.tsx
@@ -16,8 +16,8 @@ export const HomeScreen: React.FC = () => {
   return (
     <ScreenContainer>
       <View style={styles.content}>
-        <Text style={[styles.greeting, {color: theme.colors.text}]}>You are signed in.</Text>
-        <Text style={[styles.meta, {color: theme.colors.muted}]}>Role: {user?.role ?? 'Unknown'}</Text>
+        <Text style={[styles.greeting, {color: theme.roles.text.primary}]}>You are signed in.</Text>
+        <Text style={[styles.meta, {color: theme.roles.text.secondary}]}>Role: {user?.role ?? 'Unknown'}</Text>
       </View>
       <Button
         title="Go to Settings"

--- a/lobbybox-guard/src/screens/App/SettingsScreen.tsx
+++ b/lobbybox-guard/src/screens/App/SettingsScreen.tsx
@@ -14,18 +14,18 @@ export const SettingsScreen: React.FC = () => {
   return (
     <ScreenContainer>
       <View style={styles.section}>
-        <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>Profile</Text>
+        <Text style={[styles.sectionTitle, {color: theme.roles.text.primary}]}>Profile</Text>
         <View style={styles.row}>
-          <Text style={[styles.label, {color: theme.colors.muted}]}>Name</Text>
-          <Text style={[styles.value, {color: theme.colors.text}]}>{user?.displayName ?? '—'}</Text>
+          <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Name</Text>
+          <Text style={[styles.value, {color: theme.roles.text.primary}]}>{user?.displayName ?? '—'}</Text>
         </View>
         <View style={styles.row}>
-          <Text style={[styles.label, {color: theme.colors.muted}]}>Email</Text>
-          <Text style={[styles.value, {color: theme.colors.text}]}>{user?.email ?? '—'}</Text>
+          <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Email</Text>
+          <Text style={[styles.value, {color: theme.roles.text.primary}]}>{user?.email ?? '—'}</Text>
         </View>
         <View style={styles.row}>
-          <Text style={[styles.label, {color: theme.colors.muted}]}>Role</Text>
-          <Text style={[styles.value, {color: theme.colors.text}]}>{user?.role ?? '—'}</Text>
+          <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Role</Text>
+          <Text style={[styles.value, {color: theme.roles.text.primary}]}>{user?.role ?? '—'}</Text>
         </View>
       </View>
       <Button title="Sign out" onPress={logout} accessibilityLabel="Sign out" style={styles.signOut} />

--- a/lobbybox-guard/src/screens/Auth/LoginScreen.tsx
+++ b/lobbybox-guard/src/screens/Auth/LoginScreen.tsx
@@ -54,17 +54,17 @@ export const LoginScreen: React.FC = () => {
 
   return (
     <KeyboardAvoidingView
-      style={[styles.container, {backgroundColor: theme.colors.background}]}
+      style={[styles.container, {backgroundColor: theme.roles.background.default}]}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
       <View style={styles.content}>
-        <Text style={[styles.title, {color: theme.colors.primary}]}>Lobbybox Guard</Text>
+        <Text style={[styles.title, {color: theme.palette.primary.main}]}>Lobbybox Guard</Text>
         <TextInput
           placeholder="Email"
-          placeholderTextColor={theme.colors.muted}
+          placeholderTextColor={theme.roles.input.placeholder}
           value={form.email}
           autoCapitalize="none"
           keyboardType="email-address"
-          style={[styles.input, {borderColor: theme.colors.border, color: theme.colors.text}]}
+          style={[styles.input, {borderColor: theme.roles.input.border, color: theme.roles.input.text}]}
           onChangeText={value => handleChange('email', value)}
           onFocus={() => {
             setErrors(prev => ({...prev, email: undefined}));
@@ -75,13 +75,13 @@ export const LoginScreen: React.FC = () => {
           accessibilityLabel="Email address"
           accessibilityHint="Enter your email address"
         />
-        {errors.email ? <Text style={[styles.error, {color: theme.colors.notification}]}>{errors.email}</Text> : null}
+        {errors.email ? <Text style={[styles.error, {color: theme.roles.status.error}]}>{errors.email}</Text> : null}
         <TextInput
           placeholder="Password"
-          placeholderTextColor={theme.colors.muted}
+          placeholderTextColor={theme.roles.input.placeholder}
           value={form.password}
           secureTextEntry
-          style={[styles.input, {borderColor: theme.colors.border, color: theme.colors.text}]}
+          style={[styles.input, {borderColor: theme.roles.input.border, color: theme.roles.input.text}]}
           onChangeText={value => handleChange('password', value)}
           onFocus={() => {
             setErrors(prev => ({...prev, password: undefined}));
@@ -93,17 +93,20 @@ export const LoginScreen: React.FC = () => {
           accessibilityHint="Enter your account password"
         />
         {errors.password ? (
-          <Text style={[styles.error, {color: theme.colors.notification}]}>{errors.password}</Text>
+          <Text style={[styles.error, {color: theme.roles.status.error}]}>{errors.password}</Text>
         ) : null}
         {error ? <ErrorNotice error={error} variant="inline" style={styles.inlineError} /> : null}
         <TouchableOpacity
           disabled={submitting}
-          style={[styles.button, {backgroundColor: theme.colors.primary, opacity: submitting ? 0.7 : 1}]}
+          style={[
+            styles.button,
+            {backgroundColor: theme.roles.button.primary.background, opacity: submitting ? 0.7 : 1},
+          ]}
           onPress={handleSubmit}
           accessibilityRole="button"
           accessibilityLabel={submitting ? 'Signing in' : 'Login'}
           accessibilityHint="Authenticates your account">
-          <Text style={[styles.buttonLabel, {color: theme.colors.background}]}>
+          <Text style={[styles.buttonLabel, {color: theme.roles.button.primary.text}]}>
             {submitting ? 'Signing in…' : 'Login'}
           </Text>
         </TouchableOpacity>

--- a/lobbybox-guard/src/screens/Auth/NotPermittedScreen.tsx
+++ b/lobbybox-guard/src/screens/Auth/NotPermittedScreen.tsx
@@ -12,10 +12,10 @@ export const NotPermittedScreen: React.FC = () => {
   return (
     <ScreenContainer style={styles.container}>
       <View style={styles.content}>
-        <Text style={[styles.title, {color: theme.colors.text}]}>Not permitted</Text>
-        <Text style={[styles.subtitle, {color: theme.colors.muted}]}>This app is only available to Guard accounts.</Text>
+        <Text style={[styles.title, {color: theme.roles.text.primary}]}>Not permitted</Text>
+        <Text style={[styles.subtitle, {color: theme.roles.text.secondary}]}>This app is only available to Guard accounts.</Text>
         {user?.role ? (
-          <Text style={[styles.detail, {color: theme.colors.muted}]}>Current role: {user.role}</Text>
+          <Text style={[styles.detail, {color: theme.roles.text.secondary}]}>Current role: {user.role}</Text>
         ) : null}
       </View>
       <Button title="Sign out" onPress={logout} accessibilityLabel="Sign out" />

--- a/lobbybox-guard/src/theme/ThemeContext.tsx
+++ b/lobbybox-guard/src/theme/ThemeContext.tsx
@@ -1,70 +1,20 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
-import {DefaultTheme, DarkTheme, Theme as NavigationTheme} from '@react-navigation/native';
-import {corporateDarkPalette, corporateLightPalette} from './colors';
+import {AppTheme, ThemeMode, darkTheme, lightTheme} from './themes';
 
 const STORAGE_KEY = 'lobbybox_guard_theme';
 
-type AppTheme = 'light' | 'dark';
-
-type CorporateTheme = NavigationTheme & {
-  mode: AppTheme;
-  colors: NavigationTheme['colors'] & {
-    primaryVariant: string;
-    secondary: string;
-    text: string;
-    muted: string;
-    surface: string;
-  };
-};
-
 type ThemeContextValue = {
-  theme: CorporateTheme;
-  mode: AppTheme;
+  theme: AppTheme;
+  mode: ThemeMode;
   toggleTheme: () => Promise<void>;
-  setMode: (mode: AppTheme) => Promise<void>;
+  setMode: (mode: ThemeMode) => Promise<void>;
 };
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
-const createLightTheme = (): CorporateTheme => ({
-  ...DefaultTheme,
-  mode: 'light',
-  colors: {
-    ...DefaultTheme.colors,
-    primary: corporateLightPalette.primary,
-    background: corporateLightPalette.background,
-    card: corporateLightPalette.surface,
-    text: corporateLightPalette.text,
-    border: corporateLightPalette.border,
-    notification: corporateLightPalette.secondary,
-    primaryVariant: corporateLightPalette.primaryVariant,
-    secondary: corporateLightPalette.secondary,
-    muted: corporateLightPalette.muted,
-    surface: corporateLightPalette.surface,
-  },
-});
-
-const createDarkTheme = (): CorporateTheme => ({
-  ...DarkTheme,
-  mode: 'dark',
-  colors: {
-    ...DarkTheme.colors,
-    primary: corporateDarkPalette.primary,
-    background: corporateDarkPalette.background,
-    card: corporateDarkPalette.surface,
-    text: corporateDarkPalette.text,
-    border: corporateDarkPalette.border,
-    notification: corporateDarkPalette.secondary,
-    primaryVariant: corporateDarkPalette.primaryVariant,
-    secondary: corporateDarkPalette.secondary,
-    muted: corporateDarkPalette.muted,
-    surface: corporateDarkPalette.surface,
-  },
-});
-
 export const ThemeProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
-  const [mode, setModeState] = useState<AppTheme>('light');
+  const [mode, setModeState] = useState<ThemeMode>('light');
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
@@ -77,7 +27,7 @@ export const ThemeProvider: React.FC<{children: React.ReactNode}> = ({children})
     })();
   }, []);
 
-  const persistMode = useCallback(async (value: AppTheme) => {
+  const persistMode = useCallback(async (value: ThemeMode) => {
     setModeState(value);
     await AsyncStorage.setItem(STORAGE_KEY, value);
   }, []);
@@ -86,11 +36,11 @@ export const ThemeProvider: React.FC<{children: React.ReactNode}> = ({children})
     await persistMode(mode === 'light' ? 'dark' : 'light');
   }, [mode, persistMode]);
 
-  const setMode = useCallback(async (value: AppTheme) => {
+  const setMode = useCallback(async (value: ThemeMode) => {
     await persistMode(value);
   }, [persistMode]);
 
-  const theme = useMemo<CorporateTheme>(() => (mode === 'light' ? createLightTheme() : createDarkTheme()), [mode]);
+  const theme = useMemo<AppTheme>(() => (mode === 'light' ? lightTheme : darkTheme), [mode]);
 
   const value = useMemo(
     () => ({

--- a/lobbybox-guard/src/theme/colors.ts
+++ b/lobbybox-guard/src/theme/colors.ts
@@ -1,21 +1,49 @@
-export const corporateLightPalette = {
-  primary: '#d97706',
-  primaryVariant: '#b45309',
-  secondary: '#4338ca',
-  background: '#fefce8',
-  surface: '#ffffff',
-  text: '#1f2937',
-  muted: '#6b7280',
-  border: '#e5e7eb',
-};
+export const colorTokens = {
+  color: {
+    primary: {
+      main: '#FFD956',
+      dark: '#E0B500',
+      contrastText: '#2C2C2C',
+    },
+    secondary: {
+      main: '#2C2C2C',
+      contrastText: '#FFFFFF',
+    },
+    background: {
+      default: '#FAFAFA',
+    },
+    surface: {
+      card: '#FFFFFF',
+    },
+    info: {
+      main: '#4DA6FF',
+    },
+    success: {
+      main: '#3BC97E',
+    },
+    error: {
+      main: '#E85D5D',
+    },
+    border: {
+      divider: '#E0E0E0',
+    },
+    text: {
+      primary: '#2C2C2C',
+      secondary: '#666666',
+    },
+    dark: {
+      background: {
+        default: '#1A1A1A',
+      },
+      surface: {
+        card: '#2C2C2C',
+      },
+      text: {
+        primary: '#FFFFFF',
+        secondary: '#CCCCCC',
+      },
+    },
+  },
+} as const;
 
-export const corporateDarkPalette = {
-  primary: '#f59e0b',
-  primaryVariant: '#f97316',
-  secondary: '#6366f1',
-  background: '#0f172a',
-  surface: '#111827',
-  text: '#f9fafb',
-  muted: '#9ca3af',
-  border: '#1f2937',
-};
+export type ColorTokens = typeof colorTokens;

--- a/lobbybox-guard/src/theme/index.ts
+++ b/lobbybox-guard/src/theme/index.ts
@@ -1,2 +1,5 @@
-export * from './ThemeContext';
-export * from './colors';
+export {colorTokens} from './colors';
+export type {ColorTokens} from './colors';
+export {lightTheme, darkTheme} from './themes';
+export type {AppTheme, ThemeMode, ThemePalette, ThemeRoles} from './themes';
+export {ThemeProvider, useThemeContext} from './ThemeContext';

--- a/lobbybox-guard/src/theme/themes.ts
+++ b/lobbybox-guard/src/theme/themes.ts
@@ -1,0 +1,123 @@
+import {DarkTheme, DefaultTheme, Theme as NavigationTheme} from '@react-navigation/native';
+import {colorTokens} from './colors';
+
+export type ThemeMode = 'light' | 'dark';
+
+export type ThemePalette = {
+  primary: typeof colorTokens.color.primary;
+  secondary: typeof colorTokens.color.secondary;
+  background: {default: string};
+  surface: {card: string};
+  info: typeof colorTokens.color.info;
+  success: typeof colorTokens.color.success;
+  error: typeof colorTokens.color.error;
+  border: typeof colorTokens.color.border;
+  text: {primary: string; secondary: string};
+};
+
+export type ThemeRoles = {
+  button: {
+    primary: {background: string; pressed: string; text: string};
+    secondary: {background: string; border: string; text: string};
+    ghost: {text: string};
+  };
+  card: {background: string; border: string};
+  text: {primary: string; secondary: string; onPrimary: string};
+  input: {background: string; text: string; placeholder: string; border: string};
+  divider: {color: string};
+  background: {default: string};
+  status: {info: string; success: string; error: string};
+};
+
+export type AppTheme = NavigationTheme & {
+  mode: ThemeMode;
+  palette: ThemePalette;
+  roles: ThemeRoles;
+};
+
+const createTheme = (mode: ThemeMode): AppTheme => {
+  const isDark = mode === 'dark';
+
+  const palette: ThemePalette = {
+    primary: colorTokens.color.primary,
+    secondary: colorTokens.color.secondary,
+    background: {
+      default: isDark ? colorTokens.color.dark.background.default : colorTokens.color.background.default,
+    },
+    surface: {
+      card: isDark ? colorTokens.color.dark.surface.card : colorTokens.color.surface.card,
+    },
+    info: colorTokens.color.info,
+    success: colorTokens.color.success,
+    error: colorTokens.color.error,
+    border: colorTokens.color.border,
+    text: isDark ? colorTokens.color.dark.text : colorTokens.color.text,
+  };
+
+  const baseNavigation = isDark ? DarkTheme : DefaultTheme;
+
+  const navigationColors: NavigationTheme['colors'] = {
+    ...baseNavigation.colors,
+    primary: palette.primary.main,
+    background: palette.background.default,
+    card: palette.surface.card,
+    text: palette.text.primary,
+    border: palette.border.divider,
+    notification: palette.error.main,
+  };
+
+  const roles: ThemeRoles = {
+    button: {
+      primary: {
+        background: palette.primary.main,
+        pressed: palette.primary.dark,
+        text: palette.primary.contrastText,
+      },
+      secondary: {
+        background: palette.surface.card,
+        border: palette.border.divider,
+        text: palette.text.primary,
+      },
+      ghost: {
+        text: palette.primary.main,
+      },
+    },
+    card: {
+      background: palette.surface.card,
+      border: palette.border.divider,
+    },
+    text: {
+      primary: palette.text.primary,
+      secondary: palette.text.secondary,
+      onPrimary: palette.primary.contrastText,
+    },
+    input: {
+      background: palette.surface.card,
+      text: palette.text.primary,
+      placeholder: palette.text.secondary,
+      border: palette.border.divider,
+    },
+    divider: {
+      color: palette.border.divider,
+    },
+    background: {
+      default: palette.background.default,
+    },
+    status: {
+      info: palette.info.main,
+      success: palette.success.main,
+      error: palette.error.main,
+    },
+  };
+
+  return {
+    ...baseNavigation,
+    mode,
+    colors: navigationColors,
+    palette,
+    roles,
+  };
+};
+
+export const lightTheme: AppTheme = createTheme('light');
+export const darkTheme: AppTheme = createTheme('dark');


### PR DESCRIPTION
## Summary
- add LobbyBox color tokens and light/dark palettes to the shared theme
- expose theme roles for buttons, cards, inputs, dividers, and text while keeping navigation colors in sync
- refactor screens and primitives (including the splash screen) to read colors from the centralized theme

## Testing
- npm run lint *(fails: missing @react-native/eslint-config)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1e8685b008331b6d4eed0937f3d41