### PR TITLE
Add Azure App Service deployment workflow

### DIFF
--- a/.github/workflows/deploy-node-api.yml
+++ b/.github/workflows/deploy-node-api.yml
@@ -1,0 +1,79 @@
+name: Deploy Node API to Azure App Service
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.txt"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: node-api-azure-deploy
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "18.x"
+  APP_DIRECTORY: "."
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.APP_DIRECTORY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            ${{ env.APP_DIRECTORY }}/package-lock.json
+            ${{ env.APP_DIRECTORY }}/npm-shrinkwrap.json
+
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --omit=dev
+          else
+            npm install --omit=dev
+          fi
+
+      - name: Detect build script
+        id: package-json
+        run: |
+          if [ -f package.json ]; then
+            node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); const hasBuild = Boolean(pkg.scripts && pkg.scripts.build); console.log(`has_build=${hasBuild}`);" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build application
+        if: steps.package-json.outputs.has_build == 'true'
+        run: npm run build
+
+      - name: Copy deployment package
+        run: |
+          mkdir -p ../build-artifact
+          if [ -d dist ]; then
+            cp -R dist/. ../build-artifact/
+          elif [ -d build ]; then
+            cp -R build/. ../build-artifact/
+          else
+            rsync -av --exclude=node_modules --exclude=.next --exclude=.git ./ ../build-artifact/
+          fi
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: build-artifact

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # lobbybox-mobile
 
 This repository contains the Expo-managed Lobbybox Guard application. See [`lobbybox-guard/README.md`](./lobbybox-guard/README.md) for setup and development instructions.
+
+## Deployment
+
+- [Deploying a Node.js API to Azure App Service (Linux)](./docs/deployment/azure-app-service.md)

--- a/docs/deployment/azure-app-service.md
+++ b/docs/deployment/azure-app-service.md
@@ -1,0 +1,42 @@
+# Deploying a Node.js API to Azure App Service (Linux)
+
+This project now ships with a reusable GitHub Actions workflow that can deploy a Node.js API to an Azure App Service running on Linux. The workflow is designed to stay within the free tier by using GitHub-hosted runners and the standard App Service build process.
+
+## Prerequisites
+
+1. **Azure Web App**: Create an App Service (Linux) plan and a Web App configured for Node.js. The free F1 tier is sufficient for small workloads and proofs-of-concept.
+2. **Publish profile**: From the Azure Portal, download the publish profile for the Web App. Store it in the repository secrets as `AZURE_WEBAPP_PUBLISH_PROFILE`.
+3. **App name secret**: Add the Web App name as the secret `AZURE_WEBAPP_NAME` so the workflow can target the correct resource.
+4. **Repository permissions**: Ensure GitHub Actions is enabled for the repository.
+
+## Workflow overview
+
+The workflow file lives at [`.github/workflows/deploy-node-api.yml`](../../.github/workflows/deploy-node-api.yml) and runs automatically when the `main` branch is updated. You can also trigger it manually from the **Actions** tab using the `workflow_dispatch` event.
+
+### What the workflow does
+
+1. Checks out the repository.
+2. Sets up Node.js 18 (Azure App Service currently supports Node 18 on the free tier).
+3. Installs production dependencies via `npm ci --omit=dev` (falls back to `npm install` if `package-lock.json` is missing).
+4. Runs `npm run build` when a `build` script exists in `package.json`.
+5. Copies either the `dist`, `build`, or the project root (excluding `node_modules` and `.next`) into a deployment package.
+6. Deploys the package with `azure/webapps-deploy@v3` using the publish profile secret.
+
+## Customisation
+
+- **Project location**: By default the workflow expects the Node.js project at the repository root. If the API code lives in a different directory (for example `api/`), change the `APP_DIRECTORY` value near the top of the workflow file.
+- **Runtime version**: Update `NODE_VERSION` if your Web App targets a different Node.js runtime.
+- **Environment variables**: Configure production environment variables inside the Azure Portal or via App Service application settings.
+
+## Manual deployments
+
+If you need to deploy from the command line instead of relying on GitHub Actions, you can use the Azure CLI:
+
+```bash
+az webapp deploy \
+  --name <your-app-name> \
+  --resource-group <your-resource-group> \
+  --src-path <path-to-build-artifact>
+```
+
+Keep the package size small to stay within the free tier's limits.


### PR DESCRIPTION
## Summary
- add a reusable GitHub Actions workflow that deploys the Node API to Azure App Service on Linux using the free tier
- document the required Azure setup, secrets, and customization options for the workflow
- surface the new deployment documentation from the project README

## Testing
- not run (documentation and CI configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e1f078b51c833196d1364deec63f53