### PR TITLE
Implement themed toast notifications

### DIFF
--- a/lobbybox-guard/src/App.tsx
+++ b/lobbybox-guard/src/App.tsx
@@ -6,6 +6,7 @@ import {ThemeProvider} from '@/theme';
 import {AuthProvider} from '@/context/AuthContext';
 import {AppNavigator} from '@/navigation/AppNavigator';
 import {DebugProvider} from '@/debug/DebugContext';
+import {ToastHost} from '@/components/ToastHost';
 
 enableScreens();
 
@@ -14,6 +15,7 @@ const App: React.FC = () => {
     <GestureHandlerRootView style={{flex: 1}}>
       <SafeAreaProvider>
         <ThemeProvider>
+          <ToastHost />
           <DebugProvider>
             <AuthProvider>
               <AppNavigator />

--- a/lobbybox-guard/src/components/ToastHost.tsx
+++ b/lobbybox-guard/src/components/ToastHost.tsx
@@ -1,0 +1,202 @@
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {Animated, StyleSheet, Text, View} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {subscribeToToasts, ToastMessage} from '@/utils/toast';
+import {useThemeContext} from '@/theme';
+
+const ENTER_OFFSET = -16;
+const TOAST_MARGIN = 16;
+
+const animationConfig = {
+  enter: {
+    opacity: {duration: 220},
+  },
+  exit: {
+    opacity: {duration: 160},
+  },
+} as const;
+
+export const ToastHost: React.FC = () => {
+  const {theme} = useThemeContext();
+  const insets = useSafeAreaInsets();
+  const [current, setCurrent] = useState<ToastMessage | null>(null);
+  const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(ENTER_OFFSET)).current;
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queueRef = useRef<ToastMessage[]>([]);
+  const isShowingRef = useRef(false);
+
+  const showNext = useCallback(() => {
+    if (queueRef.current.length === 0) {
+      isShowingRef.current = false;
+      setCurrent(null);
+      return;
+    }
+
+    const next = queueRef.current.shift();
+    if (!next) {
+      isShowingRef.current = false;
+      setCurrent(null);
+      return;
+    }
+
+    isShowingRef.current = true;
+    setCurrent(next);
+  }, []);
+
+  const hideToast = useCallback(() => {
+    Animated.timing(opacity, {
+      toValue: 0,
+      duration: animationConfig.exit.opacity.duration,
+      useNativeDriver: true,
+    }).start(({finished}) => {
+      if (finished) {
+        translateY.setValue(ENTER_OFFSET);
+        showNext();
+      }
+    });
+  }, [opacity, showNext, translateY]);
+
+  useEffect(() => {
+    return subscribeToToasts(toast => {
+      queueRef.current.push(toast);
+      if (!isShowingRef.current) {
+        showNext();
+      }
+    });
+  }, [showNext]);
+
+  useEffect(() => {
+    if (!current) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    opacity.stopAnimation();
+    translateY.stopAnimation();
+    opacity.setValue(0);
+    translateY.setValue(ENTER_OFFSET);
+
+    Animated.parallel([
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: animationConfig.enter.opacity.duration,
+        useNativeDriver: true,
+      }),
+      Animated.spring(translateY, {
+        toValue: 0,
+        tension: 180,
+        friction: 18,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    timerRef.current = setTimeout(() => {
+      hideToast();
+    }, current.duration);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [current, hideToast, opacity, translateY]);
+
+  const accentColor = useMemo(() => {
+    const {
+      roles: {
+        status: {info, success, error},
+      },
+    } = theme;
+
+    if (!current) {
+      return info;
+    }
+
+    switch (current.type) {
+      case 'success':
+        return success;
+      case 'error':
+        return error;
+      default:
+        return info;
+    }
+  }, [current, theme]);
+
+  const cardColor = theme.roles.card.background;
+  const primaryText = theme.roles.text.primary;
+  const secondaryText = theme.roles.text.secondary;
+
+  return (
+    <View pointerEvents="none" style={[styles.wrapper, {top: insets.top + TOAST_MARGIN}]}> 
+      {current ? (
+        <Animated.View
+          accessibilityLiveRegion="polite"
+          style={[
+            styles.toast,
+            {
+              opacity,
+              transform: [{translateY}],
+              backgroundColor: cardColor,
+              shadowColor: '#000',
+            },
+          ]}>
+          <View style={[styles.accent, {backgroundColor: accentColor}]} />
+          <View style={styles.content}>
+            <Text style={[styles.message, {color: primaryText}]}>{current.message}</Text>
+            {current.subtitle ? <Text style={[styles.subtitle, {color: secondaryText}]}>{current.subtitle}</Text> : null}
+          </View>
+        </Animated.View>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    left: TOAST_MARGIN,
+    right: TOAST_MARGIN,
+    zIndex: 1000,
+    elevation: 0,
+    alignItems: 'center',
+  },
+  toast: {
+    alignSelf: 'stretch',
+    maxWidth: 480,
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderRadius: 14,
+    shadowOpacity: 0.18,
+    shadowRadius: 16,
+    shadowOffset: {width: 0, height: 6},
+    elevation: 4,
+    overflow: 'hidden',
+  },
+  accent: {
+    width: 4,
+    borderRadius: 4,
+    marginRight: 12,
+  },
+  content: {
+    flex: 1,
+  },
+  message: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  subtitle: {
+    marginTop: 4,
+    fontSize: 13,
+  },
+});

--- a/lobbybox-guard/src/utils/toast.ts
+++ b/lobbybox-guard/src/utils/toast.ts
@@ -1,33 +1,67 @@
-import {Alert, Platform, ToastAndroid} from 'react-native';
 import {ParsedApiError, getDisplayMessage} from './error';
 
-export const showToast = (message: string) => {
-  if (Platform.OS === 'android') {
-    ToastAndroid.show(message, ToastAndroid.SHORT);
-    return;
-  }
+export type ToastType = 'info' | 'success' | 'error';
 
-  Alert.alert('', message);
+export type ToastOptions = {
+  /**
+   * The style of toast to render. Defaults to `info`.
+   */
+  type?: ToastType;
+  /**
+   * Optional supporting text rendered under the main message.
+   */
+  subtitle?: string;
+  /**
+   * How long the toast should remain visible before dismissing, in milliseconds.
+   */
+  duration?: number;
+};
+
+export type ToastMessage = {
+  id: number;
+  message: string;
+  subtitle?: string;
+  type: ToastType;
+  duration: number;
+};
+
+type ToastListener = (toast: ToastMessage) => void;
+
+const listeners = new Set<ToastListener>();
+
+let counter = 0;
+
+export const subscribeToToasts = (listener: ToastListener) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const emitToast = (toast: ToastMessage) => {
+  listeners.forEach(listener => listener(toast));
+};
+
+export const showToast = (message: string, options: ToastOptions = {}) => {
+  const toast: ToastMessage = {
+    id: ++counter,
+    message,
+    subtitle: options.subtitle,
+    type: options.type ?? 'info',
+    duration: options.duration ?? 3200,
+  };
+
+  emitToast(toast);
+  return toast;
 };
 
 export const showErrorToast = (error: ParsedApiError) => {
   const message = getDisplayMessage(error);
-  if (Platform.OS === 'android') {
-    ToastAndroid.show(message, ToastAndroid.LONG);
-  }
+  const subtitle = error.requestId ? `Request ID: ${error.requestId}` : undefined;
 
-  if (error.requestId) {
-    Alert.alert('Error', message, [
-      {text: 'Close', style: 'cancel'},
-      {
-        text: 'Details',
-        onPress: () => {
-          Alert.alert('Request details', `Request ID: ${error.requestId}`);
-        },
-      },
-    ]);
-    return;
-  }
-
-  Alert.alert('Error', message);
+  showToast(message, {
+    type: 'error',
+    subtitle,
+    duration: 6000,
+  });
 };


### PR DESCRIPTION
## Summary
- add a reusable toast host component that animates and queues notifications
- update the toast utility to emit typed messages instead of showing alerts
- mount the toast host at the application root so screens can show consistent feedback

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1f110eeec833190d82472e3735a0c