### PR TITLE
Update deployment workflow for Node 22

### DIFF
--- a/.github/workflows/deploy-node-api.yml
+++ b/.github/workflows/deploy-node-api.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "18.x"
-  APP_DIRECTORY: "."
+  NODE_VERSION: "22.x"
+  APP_DIRECTORY: "lobbybox-guard"
 
 jobs:
   build-and-deploy:
@@ -38,6 +38,7 @@ jobs:
           cache-dependency-path: |
             ${{ env.APP_DIRECTORY }}/package-lock.json
             ${{ env.APP_DIRECTORY }}/npm-shrinkwrap.json
+            ${{ env.APP_DIRECTORY }}/package.json
 
       - name: Install dependencies
         run: |
@@ -62,13 +63,13 @@ jobs:
 
       - name: Copy deployment package
         run: |
-          mkdir -p ../build-artifact
+          mkdir -p build-artifact
           if [ -d dist ]; then
-            cp -R dist/. ../build-artifact/
+            cp -R dist/. build-artifact/
           elif [ -d build ]; then
-            cp -R build/. ../build-artifact/
+            cp -R build/. build-artifact/
           else
-            rsync -av --exclude=node_modules --exclude=.next --exclude=.git ./ ../build-artifact/
+            rsync -av --exclude=node_modules --exclude=.next --exclude=.git ./ build-artifact/
           fi
 
       - name: Deploy to Azure Web App


### PR DESCRIPTION
## Summary
- update the deployment workflow to use Node.js 22.x to match the Azure App Service runtime
- scope the workflow to the lobbybox-guard app directory and adjust caching to use available dependency manifests
- keep the generated build artifact inside the working directory so the deploy step can locate it

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e1f60f9d248331a480d75569e6aa3f