### PR TITLE
Add today's parcel list to guard home dashboard

### DIFF
--- a/lobbybox-guard/src/api/parcels.ts
+++ b/lobbybox-guard/src/api/parcels.ts
@@ -1,0 +1,15 @@
+import {ParcelSummary} from './types';
+import api from './client';
+
+export const fetchDailyParcels = async (
+  date: string,
+  propertyId?: string | null,
+): Promise<ParcelSummary[]> => {
+  const {data} = await api.get<ParcelSummary[]>('/parcels/daily', {
+    params: {
+      date,
+      propertyId,
+    },
+  });
+  return data;
+};

--- a/lobbybox-guard/src/api/types.ts
+++ b/lobbybox-guard/src/api/types.ts
@@ -21,6 +21,15 @@ export type DailyParcelMetric = {
   propertyId?: string | null;
 };
 
+export type ParcelSummary = {
+  id: string;
+  recipient: string;
+  unit?: string | null;
+  carrier?: string | null;
+  status?: string | null;
+  receivedAt?: string | null;
+};
+
 export type AuthResponse = {
   accessToken: string;
   refreshToken: string;

--- a/lobbybox-guard/src/storage/parcelsStorage.ts
+++ b/lobbybox-guard/src/storage/parcelsStorage.ts
@@ -1,0 +1,44 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {ParcelSummary} from '@/api/types';
+
+type CachedDailyParcels = {
+  date: string;
+  propertyId?: string | null;
+  updatedAt: string;
+  parcels: ParcelSummary[];
+};
+
+const STORAGE_PREFIX = 'lobbybox_guard_parcels_daily_';
+
+const buildKey = (date: string, propertyId?: string | null) => {
+  const suffix = propertyId ? `${propertyId}` : 'default';
+  return `${STORAGE_PREFIX}${date}_${suffix}`;
+};
+
+export const parcelsStorage = {
+  async getDailyParcels(date: string, propertyId?: string | null): Promise<CachedDailyParcels | null> {
+    try {
+      const raw = await AsyncStorage.getItem(buildKey(date, propertyId));
+      if (!raw) {
+        return null;
+      }
+      const parsed: CachedDailyParcels = JSON.parse(raw);
+      if (parsed.date !== date) {
+        return null;
+      }
+      return parsed;
+    } catch (error) {
+      return null;
+    }
+  },
+  async setDailyParcels(value: CachedDailyParcels): Promise<void> {
+    try {
+      const key = buildKey(value.date, value.propertyId);
+      await AsyncStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      // ignore cache write errors
+    }
+  },
+};
+
+export type {CachedDailyParcels};


### PR DESCRIPTION
## Summary
- fetch and cache the list of today's parcels alongside the existing daily metric
- render a card on the home screen that shows parcel recipients, metadata, and offline messaging

## Testing
- npm run lint *(fails: missing @react-native/eslint-config)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e28cb2482c83318b48d7812d304fb5