### PR TITLE
Add guard tab navigation for capture, today, history, and profile

### DIFF
--- a/lobbybox-guard/README.md
+++ b/lobbybox-guard/README.md
@@ -43,7 +43,7 @@ Set `EAS_PROJECT_ID` in your shell or CI when triggering builds so that `app.con
 ## App structure
 
 - **Authentication stack** – `LoginScreen` handles credential capture, validation, and error display.
-- **App stack** – `HomeScreen` (placeholder) and `SettingsScreen` (profile summary + sign out).
+- **App tabs** – Capture (scan workflow placeholder), Today (parcel metrics dashboard), History (previous logs placeholder), Profile (settings & sign out).
 - **Role gate** – Non-`GUARD` accounts see the `NotPermittedScreen` with a forced sign-out action.
 - **Token handling** – Access tokens live in AsyncStorage for bootstrap speed; refresh tokens are secured with `expo-secure-store`.
 - **API client** – Axios instance attaches `Authorization` headers, performs a single refresh attempt on 401, and clears the session on failure. Request IDs from error envelopes are forwarded to the debug panel.
@@ -51,7 +51,7 @@ Set `EAS_PROJECT_ID` in your shell or CI when triggering builds so that `app.con
 
 ## Smoke checklist
 
-- ✅ Login with a Guard account → land on Home with the display name in the header.
+- ✅ Login with a Guard account → land on the Today tab with the display name in the header.
 - ✅ Relaunch the app → session persists using stored tokens.
 - ✅ Expire the access token → the client refreshes once and continues the session.
 - ✅ Invalidate the refresh token → the client signs the guard out cleanly.

--- a/lobbybox-guard/package.json
+++ b/lobbybox-guard/package.json
@@ -20,6 +20,7 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",
+    "@react-navigation/bottom-tabs": "^6.6.1",
     "@react-native-community/netinfo": "^11.4.1",
     "axios": "^1.6.8",
     "expo": "~54.0.0",

--- a/lobbybox-guard/src/navigation/AppNavigator.tsx
+++ b/lobbybox-guard/src/navigation/AppNavigator.tsx
@@ -1,11 +1,14 @@
 import React, {useMemo} from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {StatusBar} from 'expo-status-bar';
 import {StyleSheet, Text, View} from 'react-native';
 import {LoginScreen} from '@/screens/Auth/LoginScreen';
 import {HomeScreen} from '@/screens/App/HomeScreen';
 import {SettingsScreen} from '@/screens/App/SettingsScreen';
+import {CaptureScreen} from '@/screens/App/CaptureScreen';
+import {HistoryScreen} from '@/screens/App/HistoryScreen';
 import {NotPermittedScreen} from '@/screens/Auth/NotPermittedScreen';
 import {useAuth} from '@/context/AuthContext';
 import {SplashScreen} from '@/components/SplashScreen';
@@ -15,9 +18,11 @@ export type AuthStackParamList = {
   Login: undefined;
 };
 
-export type AppStackParamList = {
-  Home: undefined;
-  Settings: undefined;
+export type AppTabsParamList = {
+  Capture: undefined;
+  Today: undefined;
+  History: undefined;
+  Profile: undefined;
 };
 
 export type RestrictedStackParamList = {
@@ -25,7 +30,7 @@ export type RestrictedStackParamList = {
 };
 
 const AuthStack = createNativeStackNavigator<AuthStackParamList>();
-const AppStack = createNativeStackNavigator<AppStackParamList>();
+const AppTabs = createBottomTabNavigator<AppTabsParamList>();
 const RestrictedStack = createNativeStackNavigator<RestrictedStackParamList>();
 
 const AuthNavigator = () => (
@@ -50,7 +55,7 @@ const PropertyHeaderTitle: React.FC<{title: string; subtitle?: string | null}> =
   );
 };
 
-const AppStackNavigator: React.FC = () => {
+const AppTabsNavigator: React.FC = () => {
   const {user} = useAuth();
   const propertyName = user?.property?.name?.trim();
   const propertyCode = user?.property?.code?.trim();
@@ -67,11 +72,23 @@ const AppStackNavigator: React.FC = () => {
     [greeting, propertyCode, propertyName],
   );
 
+  const {theme} = useThemeContext();
+
   return (
-    <AppStack.Navigator>
-      <AppStack.Screen name="Home" component={HomeScreen} options={{headerTitle}} />
-      <AppStack.Screen name="Settings" component={SettingsScreen} options={{title: 'Settings'}} />
-    </AppStack.Navigator>
+    <AppTabs.Navigator
+      screenOptions={{
+        headerStyle: {backgroundColor: theme.colors.card},
+        headerTintColor: theme.roles.text.primary,
+        tabBarActiveTintColor: theme.palette.primary.main,
+        tabBarInactiveTintColor: theme.roles.text.secondary,
+        tabBarStyle: {backgroundColor: theme.colors.card, borderTopColor: theme.roles.card.border},
+      }}
+    >
+      <AppTabs.Screen name="Capture" component={CaptureScreen} />
+      <AppTabs.Screen name="Today" component={HomeScreen} options={{headerTitle}} />
+      <AppTabs.Screen name="History" component={HistoryScreen} />
+      <AppTabs.Screen name="Profile" component={SettingsScreen} options={{title: 'Profile'}} />
+    </AppTabs.Navigator>
   );
 };
 
@@ -95,7 +112,7 @@ export const AppNavigator: React.FC = () => {
   return (
     <NavigationContainer theme={theme}>
       <StatusBar style={mode === 'dark' ? 'light' : 'dark'} backgroundColor={theme.colors.card} />
-      {!isAuthenticated ? <AuthNavigator /> : isGuard ? <AppStackNavigator /> : <RestrictedNavigator />}
+      {!isAuthenticated ? <AuthNavigator /> : isGuard ? <AppTabsNavigator /> : <RestrictedNavigator />}
     </NavigationContainer>
   );
 };

--- a/lobbybox-guard/src/screens/App/CaptureScreen.tsx
+++ b/lobbybox-guard/src/screens/App/CaptureScreen.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import {ScreenContainer} from '@/components/ScreenContainer';
+import {useThemeContext} from '@/theme';
+
+export const CaptureScreen: React.FC = () => {
+  const {theme} = useThemeContext();
+
+  return (
+    <ScreenContainer>
+      <View style={styles.content}>
+        <Text style={[styles.title, {color: theme.roles.text.primary}]}>Capture</Text>
+        <Text style={[styles.subtitle, {color: theme.roles.text.secondary}]}>Scan parcels to log them here.</Text>
+      </View>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+});

--- a/lobbybox-guard/src/screens/App/HistoryScreen.tsx
+++ b/lobbybox-guard/src/screens/App/HistoryScreen.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import {ScreenContainer} from '@/components/ScreenContainer';
+import {useThemeContext} from '@/theme';
+
+export const HistoryScreen: React.FC = () => {
+  const {theme} = useThemeContext();
+
+  return (
+    <ScreenContainer>
+      <View style={styles.content}>
+        <Text style={[styles.title, {color: theme.roles.text.primary}]}>History</Text>
+        <Text style={[styles.subtitle, {color: theme.roles.text.secondary}]}>Review previous parcel logs.</Text>
+      </View>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+});

--- a/lobbybox-guard/src/screens/App/HomeScreen.tsx
+++ b/lobbybox-guard/src/screens/App/HomeScreen.tsx
@@ -7,12 +7,10 @@ import {
   Text,
   View,
 } from 'react-native';
-import {useNavigation, useFocusEffect} from '@react-navigation/native';
-import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {useFocusEffect} from '@react-navigation/native';
 import {ScreenContainer} from '@/components/ScreenContainer';
 import {Button} from '@/components/Button';
 import {useAuth} from '@/context/AuthContext';
-import {AppStackParamList} from '@/navigation/AppNavigator';
 import {useThemeContext} from '@/theme';
 import {useNetworkStatus} from '@/hooks/useNetworkStatus';
 import {fetchDailyParcelMetric} from '@/api/metrics';
@@ -45,7 +43,6 @@ const formatReceivedAt = (receivedAt?: string | null) => {
 };
 
 export const HomeScreen: React.FC = () => {
-  const navigation = useNavigation<NativeStackNavigationProp<AppStackParamList>>();
   const {user, refreshProfile} = useAuth();
   const {theme} = useThemeContext();
   const {isOffline} = useNetworkStatus();
@@ -196,10 +193,6 @@ export const HomeScreen: React.FC = () => {
     fetchDashboardData({showErrors: true});
   }, [fetchDashboardData]);
 
-  const handleOpenSettings = useCallback(() => {
-    navigation.navigate('Settings');
-  }, [navigation]);
-
   const todayLabel = useMemo(
     () => new Date(todayIso).toLocaleDateString(undefined, {weekday: 'long', month: 'long', day: 'numeric'}),
     [todayIso],
@@ -328,12 +321,7 @@ export const HomeScreen: React.FC = () => {
             </View>
           </View>
         </ScrollView>
-        <Button
-          title="Go to Settings"
-          onPress={handleOpenSettings}
-          accessibilityLabel="Open settings"
-          style={styles.settingsButton}
-        />
+        <View style={styles.bottomSpacing} />
       </View>
     </ScreenContainer>
   );
@@ -397,7 +385,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
     fontSize: 13,
   },
-  settingsButton: {
+  bottomSpacing: {
     marginTop: 24,
   },
   retryButton: {


### PR DESCRIPTION
## Summary
- switch the authenticated app experience to a bottom tab navigator with Capture, Today, History, and Profile destinations
- add placeholder Capture and History screens while reusing the existing dashboard and settings views for Today and Profile
- update README documentation and dependencies to reflect the new navigation structure

## Testing
- npm run lint *(fails: missing @react-native/eslint-config in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fe188128833197bccfc6e4a3cfe8