### PR TITLE
Enhance bottom tab icons and profile menu

### DIFF
--- a/lobbybox-guard/src/navigation/AppNavigator.tsx
+++ b/lobbybox-guard/src/navigation/AppNavigator.tsx
@@ -4,6 +4,7 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {StatusBar} from 'expo-status-bar';
 import {StyleSheet, Text, View} from 'react-native';
+import {Ionicons} from '@expo/vector-icons';
 import {LoginScreen} from '@/screens/Auth/LoginScreen';
 import {HomeScreen} from '@/screens/App/HomeScreen';
 import {SettingsScreen} from '@/screens/App/SettingsScreen';
@@ -76,13 +77,17 @@ const AppTabsNavigator: React.FC = () => {
 
   return (
     <AppTabs.Navigator
-      screenOptions={{
+      screenOptions={({route}) => ({
         headerStyle: {backgroundColor: theme.colors.card},
         headerTintColor: theme.roles.text.primary,
         tabBarActiveTintColor: theme.palette.primary.main,
         tabBarInactiveTintColor: theme.roles.text.secondary,
         tabBarStyle: {backgroundColor: theme.colors.card, borderTopColor: theme.roles.card.border},
-      }}
+        tabBarIcon: ({color, size, focused}) => {
+          const iconName = getTabIconName(route.name, focused);
+          return <Ionicons name={iconName} size={size} color={color} />;
+        },
+      })}
     >
       <AppTabs.Screen name="Capture" component={CaptureScreen} />
       <AppTabs.Screen name="Today" component={HomeScreen} options={{headerTitle}} />
@@ -97,6 +102,21 @@ const RestrictedNavigator = () => (
     <RestrictedStack.Screen name="NotPermitted" component={NotPermittedScreen} />
   </RestrictedStack.Navigator>
 );
+
+const getTabIconName = (routeName: keyof AppTabsParamList, focused: boolean): keyof typeof Ionicons.glyphMap => {
+  switch (routeName) {
+    case 'Capture':
+      return focused ? 'camera' : 'camera-outline';
+    case 'Today':
+      return focused ? 'home' : 'home-outline';
+    case 'History':
+      return focused ? 'time' : 'time-outline';
+    case 'Profile':
+      return focused ? 'person' : 'person-outline';
+    default:
+      return 'ellipse-outline';
+  }
+};
 
 export const AppNavigator: React.FC = () => {
   const {status, user} = useAuth();

--- a/lobbybox-guard/src/screens/App/SettingsScreen.tsx
+++ b/lobbybox-guard/src/screens/App/SettingsScreen.tsx
@@ -1,20 +1,42 @@
-import React, {useCallback} from 'react';
-import {StyleSheet, Text, View} from 'react-native';
+import React, {useCallback, useMemo} from 'react';
+import {Alert, Pressable, ScrollView, StyleSheet, Switch, Text, View} from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import Constants from 'expo-constants';
 import {ScreenContainer} from '@/components/ScreenContainer';
-import {Button} from '@/components/Button';
 import {useAuth} from '@/context/AuthContext';
 import {useThemeContext} from '@/theme';
 import {FEATURE_FLAGS} from '@/config/env';
 import {DebugPanel} from '@/components/DebugPanel';
 import {useDebug} from '@/debug/DebugContext';
 import {showToast} from '@/utils/toast';
+import {Ionicons} from '@expo/vector-icons';
 
 export const SettingsScreen: React.FC = () => {
   const {user, logout} = useAuth();
-  const {theme} = useThemeContext();
+  const {theme, mode, toggleTheme} = useThemeContext();
   const {lastRequestId} = useDebug();
+
+  const appVersion = useMemo(() => {
+    const version =
+      Constants.expoConfig?.version ?? Constants.nativeAppVersion ?? Constants.expoVersion ?? 'unknown';
+    const build =
+      Constants.expoConfig?.runtimeVersion ?? Constants.nativeBuildVersion ?? Constants.nativeAppVersion ?? 'unknown';
+
+    return `Version ${version} (${build})`;
+  }, []);
+
+  const userName = user?.displayName ?? user?.fullName ?? user?.email ?? 'Guest';
+  const initials = useMemo(() => {
+    const source = user?.displayName ?? user?.fullName ?? user?.email ?? '';
+    if (!source) {
+      return 'G';
+    }
+    const parts = source.trim().split(/\s+/);
+    if (parts.length === 1) {
+      return parts[0].charAt(0).toUpperCase();
+    }
+    return `${parts[0].charAt(0)}${parts[parts.length - 1].charAt(0)}`.toUpperCase();
+  }, [user?.displayName, user?.email, user?.fullName]);
 
   const handleSignOut = useCallback(() => {
     logout();
@@ -26,9 +48,7 @@ export const SettingsScreen: React.FC = () => {
     const build =
       Constants.expoConfig?.runtimeVersion ?? Constants.nativeBuildVersion ?? Constants.nativeAppVersion ?? 'unknown';
 
-    const diagnostics = [`App version: ${version}`, `Build: ${build}`, `Last request ID: ${lastRequestId ?? 'N/A'}`].join(
-      '\n',
-    );
+    const diagnostics = [`App version: ${version}`, `Build: ${build}`, `Last request ID: ${lastRequestId ?? 'N/A'}`].join('\n');
 
     try {
       await Clipboard.setStringAsync(diagnostics);
@@ -38,62 +58,233 @@ export const SettingsScreen: React.FC = () => {
     }
   }, [lastRequestId]);
 
+  const handleShowProfile = useCallback(() => {
+    Alert.alert('My Profile', `${userName}\n${user?.email ?? ''}\nRole: ${user?.role ?? '—'}`);
+  }, [user?.email, user?.role, userName]);
+
+  const handleChangePassword = useCallback(() => {
+    showToast('Change password is not available yet.', {type: 'info'});
+  }, []);
+
+  const handleAbout = useCallback(() => {
+    Alert.alert('About', appVersion, [
+      {text: 'Copy diagnostics', onPress: handleCopyDiagnostics},
+      {text: 'Close', style: 'cancel'},
+    ]);
+  }, [appVersion, handleCopyDiagnostics]);
+
+  const handleToggleTheme = useCallback(() => {
+    toggleTheme();
+  }, [toggleTheme]);
+
   return (
     <ScreenContainer>
-      <View style={styles.section}>
-        <Text style={[styles.sectionTitle, {color: theme.roles.text.primary}]}>Profile</Text>
-        <View style={styles.row}>
-          <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Name</Text>
-          <Text style={[styles.value, {color: theme.roles.text.primary}]}>{user?.displayName ?? '—'}</Text>
-        </View>
-        <View style={styles.row}>
-          <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Email</Text>
-          <Text style={[styles.value, {color: theme.roles.text.primary}]}>{user?.email ?? '—'}</Text>
-        </View>
-        <View style={styles.row}>
-          <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Role</Text>
-          <Text style={[styles.value, {color: theme.roles.text.primary}]}>{user?.role ?? '—'}</Text>
-        </View>
+      <View style={styles.container}>
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.content}
+          bounces={false}
+          showsVerticalScrollIndicator={false}
+        >
+          <View
+            style={[styles.profileCard, {backgroundColor: theme.roles.card.background, borderColor: theme.roles.card.border}]}
+          >
+            <View style={[styles.avatar, {backgroundColor: theme.palette.primary.main}]}> 
+              <Text style={[styles.avatarText, {color: theme.roles.text.onPrimary}]}>{initials}</Text>
+            </View>
+            <View>
+              <Text style={[styles.profileName, {color: theme.roles.text.primary}]} numberOfLines={1}>
+                {userName}
+              </Text>
+              <Text style={[styles.profileSub, {color: theme.roles.text.secondary}]} numberOfLines={1}>
+                {user?.email ?? '—'}
+              </Text>
+            </View>
+          </View>
+
+          <View
+            style={[styles.menu, {backgroundColor: theme.roles.card.background, borderColor: theme.roles.card.border}]}
+          >
+            <MenuItem
+              icon="person-circle-outline"
+              label="My Profile"
+              onPress={handleShowProfile}
+              accessibilityLabel="View my profile"
+            />
+            <MenuItem
+              icon="key-outline"
+              label="Change Password"
+              onPress={handleChangePassword}
+              accessibilityLabel="Change password"
+            />
+            <MenuItem
+              icon={mode === 'dark' ? 'moon' : 'moon-outline'}
+              label="Dark Mode"
+              onPress={handleToggleTheme}
+              accessibilityLabel="Toggle dark mode"
+            >
+              <Switch
+                value={mode === 'dark'}
+                onValueChange={handleToggleTheme}
+                trackColor={{false: theme.roles.card.border, true: theme.palette.primary.main}}
+                thumbColor={mode === 'dark' ? theme.roles.text.primary : theme.roles.card.background}
+                ios_backgroundColor={theme.roles.card.border}
+              />
+            </MenuItem>
+            <MenuItem
+              icon="information-circle-outline"
+              label="About"
+              onPress={handleAbout}
+              accessibilityLabel="About this app"
+            />
+            <MenuItem
+              icon="log-out-outline"
+              label="Logout"
+              onPress={handleSignOut}
+              accessibilityLabel="Log out"
+              isDestructive
+              isLast
+              showChevron={false}
+            />
+          </View>
+
+          {FEATURE_FLAGS.SHOW_DEBUG_PANEL ? <View style={styles.debugPanelWrapper}><DebugPanel /></View> : null}
+        </ScrollView>
+        <Text style={[styles.version, {color: theme.roles.text.secondary}]}>{appVersion}</Text>
       </View>
-      <View style={styles.actions}>
-        <Button
-          title="Copy diagnostics"
-          onPress={handleCopyDiagnostics}
-          variant="secondary"
-          accessibilityLabel="Copy diagnostics to clipboard"
-        />
-        <Button title="Sign out" onPress={handleSignOut} accessibilityLabel="Sign out" style={styles.signOut} />
-      </View>
-      {FEATURE_FLAGS.SHOW_DEBUG_PANEL ? <DebugPanel /> : null}
     </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
-  section: {
-    marginBottom: 24,
+  container: {
+    flex: 1,
   },
-  sectionTitle: {
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingBottom: 24,
+  },
+  profileCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    borderRadius: 16,
+    borderWidth: 1,
+    marginBottom: 16,
+  },
+  avatar: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 16,
+  },
+  avatarText: {
+    fontSize: 24,
+    fontWeight: '700',
+  },
+  profileName: {
     fontSize: 18,
     fontWeight: '700',
-    marginBottom: 12,
   },
-  row: {
-    marginBottom: 12,
+  profileSub: {
+    fontSize: 14,
+    marginTop: 2,
   },
-  label: {
-    fontSize: 12,
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-    marginBottom: 4,
+  menu: {
+    borderRadius: 16,
+    borderWidth: 1,
+    overflow: 'hidden',
+    marginBottom: 16,
   },
-  value: {
+  menuItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  menuIcon: {
+    marginRight: 12,
+  },
+  menuLabel: {
     fontSize: 16,
+    fontWeight: '500',
   },
-  actions: {
-    marginTop: 8,
+  menuSpacer: {
+    flex: 1,
   },
-  signOut: {
+  version: {
+    textAlign: 'center',
+    fontSize: 12,
     marginTop: 12,
   },
+  debugPanelWrapper: {
+    marginBottom: 16,
+  },
 });
+
+type MenuItemProps = {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  onPress?: () => void;
+  children?: React.ReactNode;
+  accessibilityLabel?: string;
+  isDestructive?: boolean;
+  isLast?: boolean;
+  showChevron?: boolean;
+};
+
+const MenuItem: React.FC<MenuItemProps> = ({
+  icon,
+  label,
+  onPress,
+  children,
+  accessibilityLabel,
+  isDestructive,
+  isLast,
+  showChevron,
+}) => {
+  const {theme} = useThemeContext();
+  const shouldShowChevron = showChevron ?? !children;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={!onPress}
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityRole={onPress ? 'button' : undefined}
+      style={({pressed}) => [
+        styles.menuItem,
+        {
+          backgroundColor: pressed ? theme.palette.background.default : theme.roles.card.background,
+          borderBottomColor: theme.roles.card.border,
+          borderBottomWidth: isLast ? 0 : StyleSheet.hairlineWidth,
+        },
+      ]}
+    >
+      <Ionicons
+        name={icon}
+        size={22}
+        color={isDestructive ? theme.palette.error.main : theme.roles.text.primary}
+        style={styles.menuIcon}
+      />
+      <Text
+        style={[
+          styles.menuLabel,
+          {color: isDestructive ? theme.palette.error.main : theme.roles.text.primary},
+        ]}
+      >
+        {label}
+      </Text>
+      <View style={styles.menuSpacer} />
+      {children}
+      {onPress && shouldShowChevron ? (
+        <Ionicons name="chevron-forward" size={20} color={theme.roles.text.secondary} />
+      ) : null}
+    </Pressable>
+  );
+};


### PR DESCRIPTION
## Summary
- add Ionicons-based bottom tab icons to align with Expo guidelines
- redesign the profile/settings screen with a menu layout, theme toggle, and app version footer

## Testing
- npm run lint *(fails: missing @react-native/eslint-config)*

------
https://chatgpt.com/codex/tasks/task_e_68e300c170fc8331afaa8a2333ed02fd