### PR TITLE
Add profile detail and password change screens

### DIFF
--- a/lobbybox-guard/src/navigation/AppNavigator.tsx
+++ b/lobbybox-guard/src/navigation/AppNavigator.tsx
@@ -10,6 +10,8 @@ import {HomeScreen} from '@/screens/App/HomeScreen';
 import {SettingsScreen} from '@/screens/App/SettingsScreen';
 import {CaptureScreen} from '@/screens/App/CaptureScreen';
 import {HistoryScreen} from '@/screens/App/HistoryScreen';
+import {ProfileDetailsScreen} from '@/screens/App/ProfileDetailsScreen';
+import {ChangePasswordScreen} from '@/screens/App/ChangePasswordScreen';
 import {NotPermittedScreen} from '@/screens/Auth/NotPermittedScreen';
 import {useAuth} from '@/context/AuthContext';
 import {SplashScreen} from '@/components/SplashScreen';
@@ -26,12 +28,19 @@ export type AppTabsParamList = {
   Profile: undefined;
 };
 
+export type ProfileStackParamList = {
+  Settings: undefined;
+  ProfileDetails: undefined;
+  ChangePassword: undefined;
+};
+
 export type RestrictedStackParamList = {
   NotPermitted: undefined;
 };
 
 const AuthStack = createNativeStackNavigator<AuthStackParamList>();
 const AppTabs = createBottomTabNavigator<AppTabsParamList>();
+const ProfileStack = createNativeStackNavigator<ProfileStackParamList>();
 const RestrictedStack = createNativeStackNavigator<RestrictedStackParamList>();
 
 const AuthNavigator = () => (
@@ -53,6 +62,25 @@ const PropertyHeaderTitle: React.FC<{title: string; subtitle?: string | null}> =
         </Text>
       ) : null}
     </View>
+  );
+};
+
+const ProfileNavigator: React.FC = () => {
+  const {theme} = useThemeContext();
+
+  return (
+    <ProfileStack.Navigator
+      screenOptions={{
+        headerStyle: {backgroundColor: theme.colors.card},
+        headerTintColor: theme.roles.text.primary,
+        headerTitleStyle: {color: theme.roles.text.primary},
+        contentStyle: {backgroundColor: theme.roles.background.default},
+      }}
+    >
+      <ProfileStack.Screen name="Settings" component={SettingsScreen} options={{headerShown: false}} />
+      <ProfileStack.Screen name="ProfileDetails" component={ProfileDetailsScreen} options={{title: 'My Profile'}} />
+      <ProfileStack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{title: 'Change Password'}} />
+    </ProfileStack.Navigator>
   );
 };
 
@@ -80,19 +108,20 @@ const AppTabsNavigator: React.FC = () => {
       screenOptions={({route}) => ({
         headerStyle: {backgroundColor: theme.colors.card},
         headerTintColor: theme.roles.text.primary,
-        tabBarActiveTintColor: theme.palette.primary.main,
+        tabBarActiveTintColor: theme.roles.text.primary,
         tabBarInactiveTintColor: theme.roles.text.secondary,
         tabBarStyle: {backgroundColor: theme.colors.card, borderTopColor: theme.roles.card.border},
-        tabBarIcon: ({color, size, focused}) => {
+        tabBarIcon: ({size, focused}) => {
           const iconName = getTabIconName(route.name, focused);
-          return <Ionicons name={iconName} size={size} color={color} />;
+          const iconColor = focused ? theme.palette.primary.main : theme.roles.text.secondary;
+          return <Ionicons name={iconName} size={size} color={iconColor} />;
         },
       })}
     >
       <AppTabs.Screen name="Capture" component={CaptureScreen} />
       <AppTabs.Screen name="Today" component={HomeScreen} options={{headerTitle}} />
       <AppTabs.Screen name="History" component={HistoryScreen} />
-      <AppTabs.Screen name="Profile" component={SettingsScreen} options={{title: 'Profile'}} />
+      <AppTabs.Screen name="Profile" component={ProfileNavigator} options={{headerShown: false}} />
     </AppTabs.Navigator>
   );
 };

--- a/lobbybox-guard/src/screens/App/ChangePasswordScreen.tsx
+++ b/lobbybox-guard/src/screens/App/ChangePasswordScreen.tsx
@@ -1,0 +1,196 @@
+import React, {useState} from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {z} from 'zod';
+import {ScreenContainer} from '@/components/ScreenContainer';
+import {useThemeContext} from '@/theme';
+import api from '@/api/client';
+import {parseApiError} from '@/utils/error';
+import {showToast} from '@/utils/toast';
+import {Button} from '@/components/Button';
+import {useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {ProfileStackParamList} from '@/navigation/AppNavigator';
+
+const schema = z
+  .object({
+    currentPassword: z.string().min(1, 'Current password is required'),
+    newPassword: z
+      .string()
+      .min(8, 'New password must be at least 8 characters')
+      .regex(/^(?=.*[A-Za-z])(?=.*\d).+$/, 'Use letters and numbers for a stronger password'),
+    confirmPassword: z.string().min(1, 'Confirm your new password'),
+  })
+  .refine(data => data.newPassword === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+type FormState = {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+};
+
+type FormErrors = Partial<Record<keyof FormState, string>>;
+
+export const ChangePasswordScreen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<ProfileStackParamList>>();
+  const {theme} = useThemeContext();
+  const [form, setForm] = useState<FormState>({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleChange = (field: keyof FormState, value: string) => {
+    setForm(prev => ({...prev, [field]: value}));
+  };
+
+  const handleSubmit = async () => {
+    try {
+      schema.parse(form);
+      setErrors({});
+    } catch (validationError) {
+      if (validationError instanceof z.ZodError) {
+        const nextErrors: FormErrors = {};
+        validationError.errors.forEach(issue => {
+          if (issue.path[0]) {
+            const key = issue.path[0] as keyof FormState;
+            nextErrors[key] = issue.message;
+          }
+        });
+        setErrors(nextErrors);
+        if (validationError.errors[0]) {
+          showToast(validationError.errors[0].message, {type: 'error'});
+        }
+      }
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await api.post('/auth/change-password', {
+        currentPassword: form.currentPassword,
+        newPassword: form.newPassword,
+      });
+      showToast('Password updated successfully', {type: 'success'});
+      navigation.goBack();
+    } catch (error) {
+      const parsed = parseApiError(error, 'Unable to change password. Please try again.');
+      showToast(parsed.message, {type: 'error'});
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ScreenContainer>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+      >
+        <ScrollView
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={styles.fieldGroup}>
+            <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Current Password</Text>
+            <TextInput
+              value={form.currentPassword}
+              onChangeText={value => handleChange('currentPassword', value)}
+              secureTextEntry
+              placeholder="Enter current password"
+              placeholderTextColor={theme.roles.input.placeholder}
+              style={[styles.input, {borderColor: theme.roles.input.border, color: theme.roles.input.text}]}
+              onFocus={() => setErrors(prev => ({...prev, currentPassword: undefined}))}
+              accessibilityLabel="Current password"
+            />
+            {errors.currentPassword ? (
+              <Text style={[styles.error, {color: theme.roles.status.error}]}>{errors.currentPassword}</Text>
+            ) : null}
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={[styles.label, {color: theme.roles.text.secondary}]}>New Password</Text>
+            <TextInput
+              value={form.newPassword}
+              onChangeText={value => handleChange('newPassword', value)}
+              secureTextEntry
+              placeholder="Enter new password"
+              placeholderTextColor={theme.roles.input.placeholder}
+              style={[styles.input, {borderColor: theme.roles.input.border, color: theme.roles.input.text}]}
+              onFocus={() => setErrors(prev => ({...prev, newPassword: undefined}))}
+              accessibilityLabel="New password"
+            />
+            {errors.newPassword ? (
+              <Text style={[styles.error, {color: theme.roles.status.error}]}>{errors.newPassword}</Text>
+            ) : null}
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={[styles.label, {color: theme.roles.text.secondary}]}>Confirm Password</Text>
+            <TextInput
+              value={form.confirmPassword}
+              onChangeText={value => handleChange('confirmPassword', value)}
+              secureTextEntry
+              placeholder="Re-enter new password"
+              placeholderTextColor={theme.roles.input.placeholder}
+              style={[styles.input, {borderColor: theme.roles.input.border, color: theme.roles.input.text}]}
+              onFocus={() => setErrors(prev => ({...prev, confirmPassword: undefined}))}
+              accessibilityLabel="Confirm new password"
+            />
+            {errors.confirmPassword ? (
+              <Text style={[styles.error, {color: theme.roles.status.error}]}>{errors.confirmPassword}</Text>
+            ) : null}
+          </View>
+
+          <Button
+            title={submitting ? 'Updating…' : 'Update Password'}
+            onPress={handleSubmit}
+            disabled={submitting}
+            accessibilityHint="Saves your new password"
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  content: {
+    paddingVertical: 12,
+    gap: 20,
+  },
+  fieldGroup: {
+    gap: 8,
+  },
+  label: {
+    fontSize: 14,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    fontSize: 16,
+  },
+  error: {
+    fontSize: 13,
+  },
+});
+

--- a/lobbybox-guard/src/screens/App/ProfileDetailsScreen.tsx
+++ b/lobbybox-guard/src/screens/App/ProfileDetailsScreen.tsx
@@ -1,0 +1,92 @@
+import React, {useMemo} from 'react';
+import {ScrollView, StyleSheet, Text, View} from 'react-native';
+import {ScreenContainer} from '@/components/ScreenContainer';
+import {useAuth} from '@/context/AuthContext';
+import {useThemeContext} from '@/theme';
+
+type DetailItem = {
+  label: string;
+  value: string;
+};
+
+export const ProfileDetailsScreen: React.FC = () => {
+  const {user} = useAuth();
+  const {theme} = useThemeContext();
+
+  const details = useMemo<DetailItem[]>(() => {
+    if (!user) {
+      return [
+        {label: 'Name', value: 'Guest'},
+        {label: 'Email', value: '—'},
+        {label: 'Role', value: '—'},
+      ];
+    }
+
+    return [
+      {label: 'Name', value: user.displayName ?? user.fullName ?? '—'},
+      {label: 'Email', value: user.email ?? '—'},
+      {label: 'Role', value: formatRole(user.role)},
+      {
+        label: 'Property',
+        value: user.property?.name ? `${user.property.name}${user.property.code ? ` (${user.property.code})` : ''}` : '—',
+      },
+    ];
+  }, [user]);
+
+  return (
+    <ScreenContainer>
+      <ScrollView contentContainerStyle={styles.content} bounces={false} showsVerticalScrollIndicator={false}>
+        <View
+          style={[styles.card, {backgroundColor: theme.roles.card.background, borderColor: theme.roles.card.border}]}
+        >
+          {details.map((item, index) => (
+            <View key={item.label} style={[styles.row, index === details.length - 1 && styles.rowLast]}>
+              <Text style={[styles.label, {color: theme.roles.text.secondary}]}>{item.label}</Text>
+              <Text style={[styles.value, {color: theme.roles.text.primary}]}>{item.value || '—'}</Text>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </ScreenContainer>
+  );
+};
+
+const formatRole = (role: string): string => {
+  switch (role) {
+    case 'SUPER_ADMIN':
+      return 'Super Admin';
+    case 'PROPERTY_ADMIN':
+      return 'Property Admin';
+    case 'GUARD':
+      return 'Guard';
+    default:
+      return role;
+  }
+};
+
+const styles = StyleSheet.create({
+  content: {
+    padding: 24,
+  },
+  card: {
+    borderWidth: 1,
+    borderRadius: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  row: {
+    marginBottom: 16,
+  },
+  rowLast: {
+    marginBottom: 0,
+  },
+  label: {
+    fontSize: 14,
+    marginBottom: 4,
+  },
+  value: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+

--- a/lobbybox-guard/src/screens/App/SettingsScreen.tsx
+++ b/lobbybox-guard/src/screens/App/SettingsScreen.tsx
@@ -5,16 +5,18 @@ import Constants from 'expo-constants';
 import {ScreenContainer} from '@/components/ScreenContainer';
 import {useAuth} from '@/context/AuthContext';
 import {useThemeContext} from '@/theme';
-import {FEATURE_FLAGS} from '@/config/env';
-import {DebugPanel} from '@/components/DebugPanel';
 import {useDebug} from '@/debug/DebugContext';
 import {showToast} from '@/utils/toast';
 import {Ionicons} from '@expo/vector-icons';
+import {useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {ProfileStackParamList} from '@/navigation/AppNavigator';
 
 export const SettingsScreen: React.FC = () => {
   const {user, logout} = useAuth();
   const {theme, mode, toggleTheme} = useThemeContext();
   const {lastRequestId} = useDebug();
+  const navigation = useNavigation<NativeStackNavigationProp<ProfileStackParamList>>();
 
   const appVersion = useMemo(() => {
     const version =
@@ -59,12 +61,12 @@ export const SettingsScreen: React.FC = () => {
   }, [lastRequestId]);
 
   const handleShowProfile = useCallback(() => {
-    Alert.alert('My Profile', `${userName}\n${user?.email ?? ''}\nRole: ${user?.role ?? '—'}`);
-  }, [user?.email, user?.role, userName]);
+    navigation.navigate('ProfileDetails');
+  }, [navigation]);
 
   const handleChangePassword = useCallback(() => {
-    showToast('Change password is not available yet.', {type: 'info'});
-  }, []);
+    navigation.navigate('ChangePassword');
+  }, [navigation]);
 
   const handleAbout = useCallback(() => {
     Alert.alert('About', appVersion, [
@@ -86,10 +88,20 @@ export const SettingsScreen: React.FC = () => {
           bounces={false}
           showsVerticalScrollIndicator={false}
         >
-          <View
-            style={[styles.profileCard, {backgroundColor: theme.roles.card.background, borderColor: theme.roles.card.border}]}
+          <Pressable
+            style={({pressed}) => [
+              styles.profileCard,
+              {
+                backgroundColor: theme.roles.card.background,
+                borderColor: theme.roles.card.border,
+                opacity: pressed ? 0.96 : 1,
+              },
+            ]}
+            onPress={handleShowProfile}
+            accessibilityRole="button"
+            accessibilityLabel="View profile details"
           >
-            <View style={[styles.avatar, {backgroundColor: theme.palette.primary.main}]}> 
+            <View style={[styles.avatar, {backgroundColor: theme.palette.primary.main}]}>
               <Text style={[styles.avatarText, {color: theme.roles.text.onPrimary}]}>{initials}</Text>
             </View>
             <View>
@@ -100,7 +112,7 @@ export const SettingsScreen: React.FC = () => {
                 {user?.email ?? '—'}
               </Text>
             </View>
-          </View>
+          </Pressable>
 
           <View
             style={[styles.menu, {backgroundColor: theme.roles.card.background, borderColor: theme.roles.card.border}]}
@@ -148,7 +160,6 @@ export const SettingsScreen: React.FC = () => {
             />
           </View>
 
-          {FEATURE_FLAGS.SHOW_DEBUG_PANEL ? <View style={styles.debugPanelWrapper}><DebugPanel /></View> : null}
         </ScrollView>
         <Text style={[styles.version, {color: theme.roles.text.secondary}]}>{appVersion}</Text>
       </View>
@@ -221,9 +232,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontSize: 12,
     marginTop: 12,
-  },
-  debugPanelWrapper: {
-    marginBottom: 16,
   },
 });
 


### PR DESCRIPTION
## Summary
- add a dedicated profile stack with detail and change-password screens
- update the settings screen to open profile details, navigate to password updates, and hide the debug panel
- tweak tab styling so focused icons are yellow while labels stay dark

## Testing
- npm install *(fails: npm registry returned 403)*
- npm run lint *(fails: ESLint 9 requires eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e303c3375c83319176cd92d33bf176