### PR TITLE
Refine profile styling and version metadata

### DIFF
--- a/lobbybox-guard/app.config.ts
+++ b/lobbybox-guard/app.config.ts
@@ -25,6 +25,13 @@ export default ({config}: ConfigContext): ExpoConfig => {
 
   applyEnvironmentVariables(profile);
 
+  const appVersion = config.version ?? '1.0.0';
+  const buildNumberRaw =
+    process.env.BUILD_NUMBER ?? process.env.EAS_BUILD_ID ?? process.env.ANDROID_VERSION_CODE ?? 'dev';
+  const buildNumberValue = Number(buildNumberRaw);
+  const iosBuildNumber = Number.isNaN(buildNumberValue) ? '1' : String(buildNumberValue);
+  const androidVersionCode = Number.isNaN(buildNumberValue) ? 1 : Math.max(1, Math.floor(buildNumberValue));
+
   const featureFlags = {
     GUARD_HISTORY_LOCAL_ONLY: process.env.GUARD_HISTORY_LOCAL_ONLY ?? 'false',
     SHOW_DEBUG_PANEL: process.env.SHOW_DEBUG_PANEL ?? 'false',
@@ -34,6 +41,8 @@ export default ({config}: ConfigContext): ExpoConfig => {
     appEnv: profile,
     apiBaseUrl: process.env.API_BASE_URL ?? '',
     featureFlags,
+    appVersion,
+    buildNumber: Number.isNaN(buildNumberValue) ? buildNumberRaw : String(buildNumberValue),
   };
 
   if (process.env.EAS_PROJECT_ID) {
@@ -44,7 +53,7 @@ export default ({config}: ConfigContext): ExpoConfig => {
     ...config,
     name: 'Lobbybox Guard',
     slug: 'lobbybox-guard',
-    version: '1.0.0',
+    version: appVersion,
     orientation: 'portrait',
     scheme: 'lobbyboxguard',
     userInterfaceStyle: 'automatic',
@@ -55,11 +64,13 @@ export default ({config}: ConfigContext): ExpoConfig => {
     assetBundlePatterns: ['**/*'],
     ios: {
       supportsTablet: false,
+      buildNumber: iosBuildNumber,
     },
     android: {
       adaptiveIcon: {
         backgroundColor: '#ffffff',
       },
+      versionCode: androidVersionCode,
     },
     web: {
       bundler: 'metro',

--- a/lobbybox-guard/src/navigation/AppNavigator.tsx
+++ b/lobbybox-guard/src/navigation/AppNavigator.tsx
@@ -43,6 +43,13 @@ const AppTabs = createBottomTabNavigator<AppTabsParamList>();
 const ProfileStack = createNativeStackNavigator<ProfileStackParamList>();
 const RestrictedStack = createNativeStackNavigator<RestrictedStackParamList>();
 
+const TAB_LABELS: Record<keyof AppTabsParamList, string> = {
+  Capture: 'Capture',
+  Today: 'Today',
+  History: 'History',
+  Profile: 'Profile',
+};
+
 const AuthNavigator = () => (
   <AuthStack.Navigator screenOptions={{headerShown: false}}>
     <AuthStack.Screen name="Login" component={LoginScreen} />
@@ -111,6 +118,11 @@ const AppTabsNavigator: React.FC = () => {
         tabBarActiveTintColor: theme.roles.text.primary,
         tabBarInactiveTintColor: theme.roles.text.secondary,
         tabBarStyle: {backgroundColor: theme.colors.card, borderTopColor: theme.roles.card.border},
+        tabBarLabel: ({focused, color}) => (
+          <Text style={[tabStyles.label, {color, fontWeight: focused ? '700' : '500'}]}>
+            {TAB_LABELS[route.name]}
+          </Text>
+        ),
         tabBarIcon: ({size, focused}) => {
           const iconName = getTabIconName(route.name, focused);
           const iconColor = focused ? theme.palette.primary.main : theme.roles.text.secondary;
@@ -177,5 +189,11 @@ const headerStyles = StyleSheet.create({
   subtitle: {
     fontSize: 12,
     marginTop: 2,
+  },
+});
+
+const tabStyles = StyleSheet.create({
+  label: {
+    fontSize: 12,
   },
 });

--- a/lobbybox-guard/src/screens/App/ProfileDetailsScreen.tsx
+++ b/lobbybox-guard/src/screens/App/ProfileDetailsScreen.tsx
@@ -13,6 +13,28 @@ export const ProfileDetailsScreen: React.FC = () => {
   const {user} = useAuth();
   const {theme} = useThemeContext();
 
+  const userName = user?.displayName ?? user?.fullName ?? user?.email ?? 'Guest';
+  const email = user?.email ?? '—';
+  const propertyDisplay = useMemo(() => {
+    if (!user?.property?.name) {
+      return '—';
+    }
+    const code = user.property.code?.trim();
+    return code ? `${user.property.name} (${code})` : user.property.name;
+  }, [user?.property?.code, user?.property?.name]);
+
+  const initials = useMemo(() => {
+    const source = user?.displayName ?? user?.fullName ?? user?.email ?? '';
+    if (!source) {
+      return 'G';
+    }
+    const parts = source.trim().split(/\s+/);
+    if (parts.length === 1) {
+      return parts[0].charAt(0).toUpperCase();
+    }
+    return `${parts[0].charAt(0)}${parts[parts.length - 1].charAt(0)}`.toUpperCase();
+  }, [user?.displayName, user?.email, user?.fullName]);
+
   const details = useMemo<DetailItem[]>(() => {
     if (!user) {
       return [
@@ -36,6 +58,22 @@ export const ProfileDetailsScreen: React.FC = () => {
   return (
     <ScreenContainer>
       <ScrollView contentContainerStyle={styles.content} bounces={false} showsVerticalScrollIndicator={false}>
+        <View
+          style={[styles.headerCard, {backgroundColor: theme.roles.card.background, borderColor: theme.roles.card.border}]}
+        >
+          <View style={[styles.avatar, {backgroundColor: theme.palette.primary.main}]}>
+            <Text style={[styles.avatarText, {color: theme.roles.text.onPrimary}]}>{initials}</Text>
+          </View>
+          <Text style={[styles.headerName, {color: theme.roles.text.primary}]} numberOfLines={1}>
+            {userName}
+          </Text>
+          <Text style={[styles.headerSubtitle, {color: theme.roles.text.secondary}]} numberOfLines={1}>
+            {email}
+          </Text>
+          <Text style={[styles.headerSubtitle, {color: theme.roles.text.secondary}]} numberOfLines={1}>
+            {propertyDisplay}
+          </Text>
+        </View>
         <View
           style={[styles.card, {backgroundColor: theme.roles.card.background, borderColor: theme.roles.card.border}]}
         >
@@ -67,6 +105,35 @@ const formatRole = (role: string): string => {
 const styles = StyleSheet.create({
   content: {
     padding: 24,
+  },
+  headerCard: {
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 16,
+    paddingVertical: 24,
+    paddingHorizontal: 16,
+    marginBottom: 24,
+  },
+  avatar: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  avatarText: {
+    fontSize: 32,
+    fontWeight: '700',
+  },
+  headerName: {
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    marginTop: 4,
+    textAlign: 'center',
   },
   card: {
     borderWidth: 1,

--- a/lobbybox-guard/src/theme/colors.ts
+++ b/lobbybox-guard/src/theme/colors.ts
@@ -38,6 +38,9 @@ export const colorTokens = {
       surface: {
         card: '#2C2C2C',
       },
+      border: {
+        divider: 'rgba(255, 255, 255, 0.16)',
+      },
       text: {
         primary: '#FFFFFF',
         secondary: '#CCCCCC',

--- a/lobbybox-guard/src/theme/themes.ts
+++ b/lobbybox-guard/src/theme/themes.ts
@@ -50,7 +50,9 @@ const createTheme = (mode: ThemeMode): AppTheme => {
     info: colorTokens.color.info,
     success: colorTokens.color.success,
     error: colorTokens.color.error,
-    border: colorTokens.color.border,
+    border: {
+      divider: isDark ? colorTokens.color.dark.border.divider : colorTokens.color.border.divider,
+    },
     text: isDark ? colorTokens.color.dark.text : colorTokens.color.text,
   };
 


### PR DESCRIPTION
## Summary
- surface build metadata in app config extras so the app can always display a version/build string
- lighten dark theme borders and refresh profile screens with avatar-centric layouts and visible property info
- make selected tab labels bold for clarity across the navigation tabs

## Testing
- npm run lint *(fails: missing @react-native/eslint-config preset in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e311613e248331b9bd541d43ae0261