### PR TITLE
Handle missing expo-image-manipulator on iOS

### DIFF
--- a/lobbybox-guard/app.config.ts
+++ b/lobbybox-guard/app.config.ts
@@ -58,7 +58,7 @@ export default ({config}: ConfigContext): ExpoConfig => {
     scheme: 'lobbyboxguard',
     userInterfaceStyle: 'automatic',
     extra,
-    plugins: ['expo-camera', 'expo-image-manipulator', 'expo-file-system'],
+    plugins: ['expo-camera', 'expo-file-system'],
     updates: {
       fallbackToCacheTimeout: 0,
     },


### PR DESCRIPTION
## Summary
- remove the expo-image-manipulator config plugin reference since the package does not ship one

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e320345a348331830c2f54678bb0ba