### PR TITLE
Handle expo-image-manipulator failures gracefully

### DIFF
--- a/lobbybox-guard/app.config.ts
+++ b/lobbybox-guard/app.config.ts
@@ -58,7 +58,7 @@ export default ({config}: ConfigContext): ExpoConfig => {
     scheme: 'lobbyboxguard',
     userInterfaceStyle: 'automatic',
     extra,
-    plugins: ['expo-camera', 'expo-image-manipulator', 'expo-file-system'],
+    plugins: ['expo-camera', 'expo-file-system'],
     updates: {
       fallbackToCacheTimeout: 0,
     },

--- a/lobbybox-guard/src/screens/App/CaptureScreen.tsx
+++ b/lobbybox-guard/src/screens/App/CaptureScreen.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import {CameraView, CameraViewRef, useCameraPermissions} from 'expo-camera';
 import * as FileSystem from 'expo-file-system';
-import {manipulateAsync, SaveFormat} from 'expo-image-manipulator';
+import * as ImageManipulator from 'expo-image-manipulator';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MaterialCommunityIcons} from '@expo/vector-icons';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
@@ -149,17 +149,36 @@ export const CaptureScreen: React.FC = () => {
           ]
         : [];
 
-      const result = await manipulateAsync(uri, actions, {
-        compress: 0.8,
-        format: SaveFormat.JPEG,
-      });
+      const manipulator = ImageManipulator?.manipulateAsync;
+      const hasManipulator = typeof manipulator === 'function';
 
-      const info = await FileSystem.getInfoAsync(result.uri);
+      let result: {uri: string; width?: number; height?: number} = {uri};
+      let manipulated = false;
+
+      if (hasManipulator) {
+        try {
+          result = await manipulator(uri, actions, {
+            compress: 0.8,
+            format: ImageManipulator?.SaveFormat?.JPEG ?? 'jpeg',
+          });
+          manipulated = true;
+        } catch (error) {
+          console.warn(
+            'expo-image-manipulator failed; returning original photo without resizing or compression.',
+            error,
+          );
+        }
+      } else if (actions.length > 0) {
+        console.warn('expo-image-manipulator is unavailable; returning original photo without resizing.');
+      }
+
+      const resolvedUri = result.uri ?? uri;
+      const info = await FileSystem.getInfoAsync(resolvedUri);
 
       return {
-        uri: result.uri,
-        width: result.width ?? targetWidth,
-        height: result.height ?? targetHeight,
+        uri: resolvedUri,
+        width: result.width ?? (manipulated ? targetWidth : resolved.width),
+        height: result.height ?? (manipulated ? targetHeight : resolved.height),
         size: info.exists ? info.size : undefined,
       };
     },


### PR DESCRIPTION
## Summary
- guard the capture flow against expo-image-manipulator throwing in development by catching failures
- fall back to the original photo data when manipulation is unavailable so iOS development builds can still capture images

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e320345a348331830c2f54678bb0ba