### PR TITLE
Load expo-image-manipulator dynamically

### DIFF
--- a/lobbybox-guard/app.config.ts
+++ b/lobbybox-guard/app.config.ts
@@ -58,7 +58,7 @@ export default ({config}: ConfigContext): ExpoConfig => {
     scheme: 'lobbyboxguard',
     userInterfaceStyle: 'automatic',
     extra,
-    plugins: ['expo-camera', 'expo-image-manipulator', 'expo-file-system'],
+    plugins: ['expo-camera', 'expo-file-system'],
     updates: {
       fallbackToCacheTimeout: 0,
     },

--- a/lobbybox-guard/src/screens/App/CaptureScreen.tsx
+++ b/lobbybox-guard/src/screens/App/CaptureScreen.tsx
@@ -14,7 +14,6 @@ import {
 } from 'react-native';
 import {CameraView, CameraViewRef, useCameraPermissions} from 'expo-camera';
 import * as FileSystem from 'expo-file-system';
-import {manipulateAsync, SaveFormat} from 'expo-image-manipulator';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MaterialCommunityIcons} from '@expo/vector-icons';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
@@ -31,6 +30,46 @@ import {parcelEvents} from '@/events/parcelEvents';
 import {AppTabsParamList} from '@/navigation/AppNavigator';
 
 const LONGEST_EDGE_TARGET = 1400;
+
+type ImageManipulatorModule = typeof import('expo-image-manipulator');
+
+let cachedImageManipulator: ImageManipulatorModule | null | undefined;
+let loggedManipulatorUnavailable = false;
+let loggedManipulatorFailure = false;
+
+const loadImageManipulator = async (): Promise<ImageManipulatorModule | null> => {
+  if (Platform.OS === 'web') {
+    cachedImageManipulator = null;
+    return null;
+  }
+
+  if (cachedImageManipulator !== undefined) {
+    return cachedImageManipulator;
+  }
+
+  try {
+    const module = await import('expo-image-manipulator');
+    if (module && typeof module.manipulateAsync === 'function') {
+      cachedImageManipulator = module;
+      return module;
+    }
+  } catch (error) {
+    if (!loggedManipulatorUnavailable) {
+      console.warn('expo-image-manipulator failed to load; continuing without optimization.', error);
+      loggedManipulatorUnavailable = true;
+    }
+    cachedImageManipulator = null;
+    return null;
+  }
+
+  cachedImageManipulator = null;
+  if (!loggedManipulatorUnavailable) {
+    console.warn('expo-image-manipulator is unavailable; continuing without optimization.');
+    loggedManipulatorUnavailable = true;
+  }
+
+  return cachedImageManipulator;
+};
 
 type Step = 'camera' | 'preview' | 'details' | 'success';
 
@@ -149,17 +188,42 @@ export const CaptureScreen: React.FC = () => {
           ]
         : [];
 
-      const result = await manipulateAsync(uri, actions, {
-        compress: 0.8,
-        format: SaveFormat.JPEG,
-      });
+      let result: {uri: string; width?: number; height?: number} = {uri};
+      let manipulated = false;
 
-      const info = await FileSystem.getInfoAsync(result.uri);
+      if (actions.length > 0) {
+        const manipulator = await loadImageManipulator();
+        if (manipulator) {
+          try {
+            const options: Parameters<typeof manipulator.manipulateAsync>[2] = {
+              compress: 0.8,
+              ...(manipulator.SaveFormat?.JPEG ? {format: manipulator.SaveFormat.JPEG} : {}),
+            };
+
+            result = await manipulator.manipulateAsync(uri, actions, options);
+            manipulated = true;
+          } catch (error) {
+            if (!loggedManipulatorFailure) {
+              console.warn(
+                'expo-image-manipulator failed; returning original photo without resizing or compression.',
+                error,
+              );
+              loggedManipulatorFailure = true;
+            }
+          }
+        } else if (!loggedManipulatorUnavailable) {
+          console.warn('expo-image-manipulator is unavailable; returning original photo without resizing.');
+          loggedManipulatorUnavailable = true;
+        }
+      }
+
+      const resolvedUri = result.uri ?? uri;
+      const info = await FileSystem.getInfoAsync(resolvedUri);
 
       return {
-        uri: result.uri,
-        width: result.width ?? targetWidth,
-        height: result.height ?? targetHeight,
+        uri: resolvedUri,
+        width: result.width ?? (manipulated ? targetWidth : resolved.width),
+        height: result.height ?? (manipulated ? targetHeight : resolved.height),
         size: info.exists ? info.size : undefined,
       };
     },


### PR DESCRIPTION
## Summary
- lazily import `expo-image-manipulator` at runtime so capture falls back cleanly when the native module is missing
- cache the module availability and log failures once while still returning the original image data

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e320345a348331830c2f54678bb0ba