### PR TITLE
Fix expo-file-system upload deprecation

### DIFF
--- a/lobbybox-guard/src/screens/App/CaptureScreen.tsx
+++ b/lobbybox-guard/src/screens/App/CaptureScreen.tsx
@@ -14,8 +14,7 @@ import {
   View,
 } from 'react-native';
 import {CameraView, CameraViewRef, useCameraPermissions} from 'expo-camera';
-import {createUploadTask} from 'expo-file-system';
-import {getInfoAsync} from 'expo-file-system/legacy';
+import {createUploadTask, getInfoAsync} from 'expo-file-system/legacy';
 import * as ImageManipulator from 'expo-image-manipulator';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MaterialCommunityIcons} from '@expo/vector-icons';

--- a/lobbybox-guard/src/types/expo-file-system.d.ts
+++ b/lobbybox-guard/src/types/expo-file-system.d.ts
@@ -1,4 +1,4 @@
-declare module 'expo-file-system' {
+declare module 'expo-file-system/legacy' {
   export enum FileSystemUploadType {
     BINARY_CONTENT = 'binary',
   }


### PR DESCRIPTION
## Summary
- import the legacy expo-file-system upload task to avoid the runtime deprecation error
- retarget the local TypeScript declarations to the legacy module path

## Testing
- npm run lint *(fails: ESLint couldn't find the config "@react-native/eslint-config")*


------
https://chatgpt.com/codex/tasks/task_e_68e342d2dfe88331b9f987d57d955992