### PR TITLE
Hide scroll indicators across app screens

### DIFF
--- a/lobbybox-guard/src/screens/App/CaptureScreen.tsx
+++ b/lobbybox-guard/src/screens/App/CaptureScreen.tsx
@@ -865,7 +865,8 @@ export const CaptureScreen: React.FC = () => {
             },
           ]}
           contentInsetAdjustmentBehavior="never"
-          keyboardShouldPersistTaps="handled">
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}>
           <Image
             source={{ uri: parcelPhoto.uri }}
             style={[styles.previewImage, { aspectRatio: parcelPhoto.width / parcelPhoto.height }]}
@@ -954,7 +955,8 @@ export const CaptureScreen: React.FC = () => {
             },
           ]}
           contentInsetAdjustmentBehavior="never"
-          keyboardShouldPersistTaps="handled">
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}>
           <Text style={[styles.previewContextLabel, { color: theme.roles.text.secondary }]}>Collector photo</Text>
           <Image
             source={{ uri: personPhoto.uri }}
@@ -1024,7 +1026,8 @@ export const CaptureScreen: React.FC = () => {
           },
         ]}
         contentInsetAdjustmentBehavior="never"
-        keyboardShouldPersistTaps="handled">
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}>
         <Text style={[styles.detailsTitle, { color: theme.roles.text.primary }]}>
           {entryMode === 'manual' ? 'Enter parcel details' : 'Confirm parcel details'}
         </Text>
@@ -1190,7 +1193,8 @@ export const CaptureScreen: React.FC = () => {
           paddingBottom: 24 + Math.max(insets.bottom - 8, 0),
         },
       ]}
-      contentInsetAdjustmentBehavior="never">
+      contentInsetAdjustmentBehavior="never"
+      showsVerticalScrollIndicator={false}>
       <Text style={[styles.successTitle, { color: theme.roles.text.primary }]}>Parcel recorded</Text>
       <Text style={[styles.successSubtitle, { color: theme.roles.text.secondary }]}>You can capture another or review today's log.</Text>
       {parcelPhoto ? (

--- a/lobbybox-guard/src/screens/App/HistoryScreen.tsx
+++ b/lobbybox-guard/src/screens/App/HistoryScreen.tsx
@@ -658,6 +658,7 @@ export const HistoryScreen: React.FC = () => {
         ListEmptyComponent={listEmpty}
         onEndReachedThreshold={0.2}
         onEndReached={handleLoadMore}
+        showsVerticalScrollIndicator={false}
       />
       <Modal visible={photoPreview.visible} transparent animationType="fade" onRequestClose={closePhotoPreview}>
         <View style={styles.modalBackdrop}>
@@ -669,7 +670,8 @@ export const HistoryScreen: React.FC = () => {
             <ScrollView
               style={styles.modalScroll}
               contentContainerStyle={styles.modalScrollContent}
-              alwaysBounceVertical={false}>
+              alwaysBounceVertical={false}
+              showsVerticalScrollIndicator={false}>
               <Text style={[styles.modalTitle, {color: theme.roles.text.primary}]}>Parcel photo</Text>
               {photoPreview.recipient ? (
                 <Text style={[styles.modalMeta, {color: theme.roles.text.secondary}]}>Recipient: {photoPreview.recipient}</Text>

--- a/lobbybox-guard/src/screens/App/HomeScreen.tsx
+++ b/lobbybox-guard/src/screens/App/HomeScreen.tsx
@@ -499,7 +499,8 @@ export const HomeScreen: React.FC = () => {
               tintColor={theme.palette.primary.main}
               colors={[theme.palette.primary.main]}
             />
-          }>
+          }
+          showsVerticalScrollIndicator={false}>
           <View style={styles.content}>
             {isOffline ? <OfflineBanner /> : null}
             <View
@@ -591,7 +592,8 @@ export const HomeScreen: React.FC = () => {
             <ScrollView
               style={styles.modalScroll}
               contentContainerStyle={styles.modalScrollContent}
-              alwaysBounceVertical={false}>
+              alwaysBounceVertical={false}
+              showsVerticalScrollIndicator={false}>
               <Text style={[styles.modalTitle, {color: theme.roles.text.primary}]}>Parcel photo</Text>
               {photoPreview.recipient ? (
                 <Text style={[styles.modalMeta, {color: theme.roles.text.secondary}]}>Recipient: {photoPreview.recipient}</Text>


### PR DESCRIPTION
## Summary
- hide vertical scroll indicators on the Home, History, and Capture screens
- apply the same scrollbar hiding to modal and success scroll views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec88a5103c8331bfa75997699262ef